### PR TITLE
refactor(content): centralize collection metadata in registry

### DIFF
--- a/apps/blakepetersen.io/src/app/api/og/route.tsx
+++ b/apps/blakepetersen.io/src/app/api/og/route.tsx
@@ -2,16 +2,8 @@
 // ABOUTME: Serves OG images via query params to avoid catch-all route conflicts.
 
 import { type NextRequest } from 'next/server'
-import { getSkills, getHooks, getConfigs, getGuides, getPosts } from '../../../lib/content'
+import { getCollection } from '../../../lib/collection-registry'
 import { renderOgImage } from '../../../lib/og-image'
-
-const collectionGetters: Record<string, () => { slug: string; title: string }[]> = {
-  skills: getSkills,
-  hooks: getHooks,
-  configs: getConfigs,
-  guides: getGuides,
-  posts: getPosts,
-}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl
@@ -22,12 +14,14 @@ export async function GET(request: NextRequest) {
     return new Response('Missing slug or category', { status: 400 })
   }
 
-  const getter = collectionGetters[category]
-  if (!getter) {
+  let collection
+  try {
+    collection = getCollection(category)
+  } catch {
     return new Response('Invalid category', { status: 400 })
   }
 
-  const items = getter()
+  const items = collection.getter()
   const item = items.find((i) => i.slug === slug)
   const title = item?.title ?? category
 

--- a/apps/blakepetersen.io/src/app/feed.xml/route.ts
+++ b/apps/blakepetersen.io/src/app/feed.xml/route.ts
@@ -1,7 +1,7 @@
 // ABOUTME: RSS 2.0 feed generator for all content collections.
 // ABOUTME: Statically generated at build time, serves XML at /feed.xml.
 
-import { getSkills, getHooks, getConfigs, getGuides, getPosts } from '../../lib/content'
+import { getAllCollections } from '../../lib/collection-registry'
 import { escapeXml } from '../../lib/metadata'
 
 export const dynamic = 'force-static'
@@ -36,13 +36,12 @@ function buildItem(item: FeedItem): string {
 }
 
 export async function GET(): Promise<Response> {
-  const posts = getPosts()
-  const dxItems = [
-    ...getSkills(),
-    ...getHooks(),
-    ...getConfigs(),
-    ...getGuides(),
-  ]
+  const feedCollections = getAllCollections().filter((c) => c.showInFeed)
+  const postCollection = feedCollections.find((c) => c.slug === 'posts')
+  const posts = postCollection ? postCollection.getter() : []
+  const dxItems = feedCollections
+    .filter((c) => c.slug !== 'posts')
+    .flatMap((c) => c.getter())
 
   // Posts sorted by date descending (already sorted from getPosts), then DX content
   const items = [...posts, ...dxItems]

--- a/apps/blakepetersen.io/src/app/page.tsx
+++ b/apps/blakepetersen.io/src/app/page.tsx
@@ -2,17 +2,12 @@
 // ABOUTME: Displays dynamic counts and recent items from all content collections.
 
 import Link from 'next/link'
-import { getSkills, getHooks, getConfigs, getGuides, getPosts } from '../lib/content'
+import { getAllCollections, getCollection } from '../lib/collection-registry'
 import { CategoryCard } from '../components/category-card'
 
 export const revalidate = 3600
 
-const categories = [
-  { name: 'skills', label: 'skills', getter: getSkills, href: '/skills' },
-  { name: 'hooks', label: 'hooks', getter: getHooks, href: '/hooks' },
-  { name: 'configs', label: 'configs', getter: getConfigs, href: '/configs' },
-  { name: 'guides', label: 'guides', getter: getGuides, href: '/guides' },
-] as const
+const categories = getAllCollections().filter((c) => c.slug !== 'posts')
 
 const stackTools = ['Next.js', 'TypeScript', 'Tailwind', 'Claude', 'pnpm', 'Velite', 'Turborepo', 'ESLint', 'Prettier']
 
@@ -22,7 +17,8 @@ function stripPrefix(slug: string) {
 }
 
 export default function Home() {
-  const posts = getPosts()
+  // Cast needed: posts have date/readingTime fields beyond the base getter return type
+  const posts = getCollection('posts').getter() as { slug: string; title: string; description: string; date: string; readingTime: number; [key: string]: unknown }[]
   const recentPosts = posts.slice(0, 5)
 
   return (
@@ -59,13 +55,13 @@ export default function Home() {
       <section className="mb-12">
         <p className="mb-4 font-mono text-xs text-muted-foreground">{'// collections'}</p>
         <div className="grid gap-4 md:grid-cols-2">
-          {categories.map(({ name, label, getter, href }) => {
+          {categories.map(({ slug, label, getter, href }) => {
             const items = getter()
             return (
               <CategoryCard
-                key={name}
-                name={name}
-                label={label}
+                key={slug}
+                name={slug}
+                label={label.toLowerCase()}
                 count={items.length}
                 recentItems={items.slice(0, 3).map((item) => ({
                   title: item.title,

--- a/apps/blakepetersen.io/src/app/sitemap.ts
+++ b/apps/blakepetersen.io/src/app/sitemap.ts
@@ -2,29 +2,22 @@
 // ABOUTME: Lists homepage, listing pages, and all content items for search engine discovery.
 
 import type { MetadataRoute } from 'next'
-import { getSkills, getHooks, getConfigs, getGuides, getPosts, getAllGitHistory } from '../lib/content'
+import { getAllGitHistory } from '../lib/content'
+import { getAllCollections } from '../lib/collection-registry'
 
 const BASE_URL = 'https://blakepetersen.io'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date()
 
+  const allCollections = getAllCollections().filter((c) => c.showInSitemap)
+
   const staticPages: MetadataRoute.Sitemap = [
     { url: BASE_URL, lastModified: now },
-    { url: `${BASE_URL}/skills`, lastModified: now },
-    { url: `${BASE_URL}/hooks`, lastModified: now },
-    { url: `${BASE_URL}/configs`, lastModified: now },
-    { url: `${BASE_URL}/guides`, lastModified: now },
-    { url: `${BASE_URL}/posts`, lastModified: now },
+    ...allCollections.map((c) => ({ url: `${BASE_URL}${c.href}`, lastModified: now })),
   ]
 
-  const collections = [
-    getSkills(),
-    getHooks(),
-    getConfigs(),
-    getGuides(),
-    getPosts(),
-  ]
+  const collections = allCollections.map((c) => c.getter())
 
   const gitHistory = getAllGitHistory()
 

--- a/apps/blakepetersen.io/src/app/start-here/page.tsx
+++ b/apps/blakepetersen.io/src/app/start-here/page.tsx
@@ -3,7 +3,7 @@
 
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { getSkills, getHooks, getConfigs, getGuides } from '../../lib/content'
+import { getCollection } from '../../lib/collection-registry'
 
 export const metadata: Metadata = {
   title: 'Start Here',
@@ -23,19 +23,12 @@ const steps: Step[] = [
   { collection: 'skills', slug: 'skills/claude-code/writing-custom-skills', why: 'Teach your AI assistant project-specific patterns.' },
 ]
 
-const collectionGetters = {
-  configs: getConfigs,
-  hooks: getHooks,
-  skills: getSkills,
-  guides: getGuides,
-} as const
-
 function resolveSteps() {
   const resolved: { title: string; href: string; why: string; number: number }[] = []
   let number = 1
 
   for (const step of steps) {
-    const items = collectionGetters[step.collection]()
+    const items = getCollection(step.collection).getter()
     const match = items.find((item) => item.slug === step.slug)
     if (match) {
       resolved.push({

--- a/apps/blakepetersen.io/src/components/sidebar-nav.tsx
+++ b/apps/blakepetersen.io/src/components/sidebar-nav.tsx
@@ -8,14 +8,6 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import type { NavSection } from '../lib/navigation'
 
-const categoryColors: Record<string, string> = {
-  Skills: '#F59E0B',
-  Hooks: '#06B6D4',
-  Configs: '#10B981',
-  Guides: '#9CA3AF',
-  Posts: '#6B7280',
-}
-
 export function SidebarNav({ sections }: { sections: NavSection[] }) {
   const pathname = usePathname()
 
@@ -53,7 +45,7 @@ export function SidebarNav({ sections }: { sections: NavSection[] }) {
               className="flex w-full items-center justify-between py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
               <span>
-                <span className="mr-1.5 text-[8px]" style={{ color: categoryColors[section.label] || '#6B7280' }}>●</span>
+                <span className="mr-1.5 text-[8px]" style={{ color: section.color }}>●</span>
                 {'// '}{section.label.toLowerCase()}
               </span>
               <span className="flex items-center gap-1.5">

--- a/apps/blakepetersen.io/src/lib/collection-registry.ts
+++ b/apps/blakepetersen.io/src/lib/collection-registry.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Single source of truth for content collection metadata (slugs, labels, colors, visibility).
+// ABOUTME: Eliminates hardcoded collection data scattered across components and routes.
+
+import {
+  getSkills,
+  getHooks,
+  getConfigs,
+  getGuides,
+  getPosts,
+} from './content'
+
+export type CollectionDefinition = {
+  slug: string
+  label: string
+  color: string
+  showInNav: boolean
+  showInSitemap: boolean
+  showInFeed: boolean
+  href: string
+  getter: () => { slug: string; title: string; description: string; [key: string]: unknown }[]
+}
+
+const collections: Record<string, CollectionDefinition> = {
+  skills: {
+    slug: 'skills',
+    label: 'Skills',
+    color: '#F59E0B',
+    showInNav: true,
+    showInSitemap: true,
+    showInFeed: true,
+    href: '/skills',
+    getter: getSkills,
+  },
+  hooks: {
+    slug: 'hooks',
+    label: 'Hooks',
+    color: '#06B6D4',
+    showInNav: true,
+    showInSitemap: true,
+    showInFeed: true,
+    href: '/hooks',
+    getter: getHooks,
+  },
+  configs: {
+    slug: 'configs',
+    label: 'Configs',
+    color: '#10B981',
+    showInNav: true,
+    showInSitemap: true,
+    showInFeed: true,
+    href: '/configs',
+    getter: getConfigs,
+  },
+  guides: {
+    slug: 'guides',
+    label: 'Guides',
+    color: '#9CA3AF',
+    showInNav: true,
+    showInSitemap: true,
+    showInFeed: true,
+    href: '/guides',
+    getter: getGuides,
+  },
+  posts: {
+    slug: 'posts',
+    label: 'Posts',
+    color: '#6B7280',
+    showInNav: true,
+    showInSitemap: true,
+    showInFeed: true,
+    href: '/posts',
+    getter: getPosts,
+  },
+}
+
+export function getCollection(slug: string): CollectionDefinition {
+  const collection = collections[slug]
+  if (!collection) {
+    throw new Error(`Unknown collection: ${slug}`)
+  }
+  return collection
+}
+
+export function getAllCollections(): CollectionDefinition[] {
+  return Object.values(collections)
+}
+
+export function getVisibleCollections(): CollectionDefinition[] {
+  return Object.values(collections).filter((c) => c.showInNav)
+}

--- a/apps/blakepetersen.io/src/lib/navigation.ts
+++ b/apps/blakepetersen.io/src/lib/navigation.ts
@@ -1,13 +1,7 @@
 // ABOUTME: Navigation data types and builder functions for sidebar and prev/next links.
 // ABOUTME: Transforms content collections into hierarchical navigation sections.
 
-import {
-  getSkills,
-  getHooks,
-  getConfigs,
-  getGuides,
-  getPosts,
-} from './content'
+import { getVisibleCollections } from './collection-registry'
 
 export type NavItem = {
   title: string
@@ -18,6 +12,7 @@ export type NavItem = {
 export type NavSection = {
   label: string
   href: string
+  color: string
   items: NavItem[]
 }
 
@@ -36,35 +31,19 @@ function collectionToItems(
 }
 
 export function buildNavSections(): NavSection[] {
+  const collectionSections: NavSection[] = getVisibleCollections().map((c) => ({
+    label: c.label,
+    href: c.href,
+    color: c.color,
+    items: collectionToItems(c.slug, c.getter()),
+  }))
+
   return [
-    {
-      label: 'Skills',
-      href: '/skills',
-      items: collectionToItems('skills', getSkills()),
-    },
-    {
-      label: 'Hooks',
-      href: '/hooks',
-      items: collectionToItems('hooks', getHooks()),
-    },
-    {
-      label: 'Configs',
-      href: '/configs',
-      items: collectionToItems('configs', getConfigs()),
-    },
-    {
-      label: 'Guides',
-      href: '/guides',
-      items: collectionToItems('guides', getGuides()),
-    },
-    {
-      label: 'Posts',
-      href: '/posts',
-      items: collectionToItems('posts', getPosts()),
-    },
+    ...collectionSections,
     {
       label: 'Project',
       href: '/changelog',
+      color: '#6B7280',
       items: [
         { title: 'Changelog', slug: 'changelog', href: '/changelog' },
         { title: 'Contributors', slug: 'contributors', href: '/contributors' },

--- a/apps/blakepetersen.io/tests/collection-registry.test.ts
+++ b/apps/blakepetersen.io/tests/collection-registry.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for the centralized collection registry.
+// ABOUTME: Validates required fields, visibility filtering, and unknown slug handling.
+
+import {
+  getAllCollections,
+  getVisibleCollections,
+  getCollection,
+} from '@/lib/collection-registry'
+
+// Mock the content module so tests don't depend on Velite build output
+jest.mock('@/lib/content', () => ({
+  getSkills: () => [{ slug: 'skills/a', title: 'Skill A' }],
+  getHooks: () => [{ slug: 'hooks/a', title: 'Hook A' }],
+  getConfigs: () => [{ slug: 'configs/a', title: 'Config A' }],
+  getGuides: () => [{ slug: 'guides/a', title: 'Guide A' }],
+  getPosts: () => [{ slug: 'posts/a', title: 'Post A' }],
+}))
+
+describe('collection-registry', () => {
+  describe('getAllCollections', () => {
+    it('returns all five content collections', () => {
+      const all = getAllCollections()
+      expect(all).toHaveLength(5)
+      expect(all.map((c) => c.slug)).toEqual([
+        'skills',
+        'hooks',
+        'configs',
+        'guides',
+        'posts',
+      ])
+    })
+
+    it('every collection has all required fields', () => {
+      for (const c of getAllCollections()) {
+        expect(c.slug).toBeTruthy()
+        expect(c.label).toBeTruthy()
+        expect(c.color).toMatch(/^#[0-9A-Fa-f]{6}$/)
+        expect(typeof c.showInNav).toBe('boolean')
+        expect(typeof c.showInSitemap).toBe('boolean')
+        expect(typeof c.showInFeed).toBe('boolean')
+        expect(c.href).toMatch(/^\//)
+        expect(typeof c.getter).toBe('function')
+      }
+    })
+
+    it('each getter returns an array', () => {
+      for (const c of getAllCollections()) {
+        expect(Array.isArray(c.getter())).toBe(true)
+      }
+    })
+  })
+
+  describe('getVisibleCollections', () => {
+    it('returns only collections with showInNav=true', () => {
+      const visible = getVisibleCollections()
+      for (const c of visible) {
+        expect(c.showInNav).toBe(true)
+      }
+    })
+
+    it('returns a subset of all collections', () => {
+      const visible = getVisibleCollections()
+      const all = getAllCollections()
+      expect(visible.length).toBeLessThanOrEqual(all.length)
+      for (const c of visible) {
+        expect(all).toContainEqual(c)
+      }
+    })
+  })
+
+  describe('getCollection', () => {
+    it('returns the correct collection for a known slug', () => {
+      const skills = getCollection('skills')
+      expect(skills.slug).toBe('skills')
+      expect(skills.label).toBe('Skills')
+      expect(skills.color).toBe('#F59E0B')
+    })
+
+    it('throws on unknown slug', () => {
+      expect(() => getCollection('nonexistent')).toThrow(
+        'Unknown collection: nonexistent',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Closes #83

- Creates `collection-registry.ts` as single source of truth for collection slugs, labels, colors, and behavioral flags
- Migrates 7 consumer files to import from registry instead of hardcoding metadata
- Removes YAGNI fields (pluralLabel, icon, sortField, sortDirection) per review
- Adds registry unit tests

## Consumers migrated
- `sidebar-nav.tsx` — categoryColors replaced with registry lookup
- `navigation.ts` — nav sections built from registry
- `sitemap.ts` — URL generation from registry
- `page.tsx` (homepage) — category grid from registry
- `api/og/route.tsx` — collection-to-getter mapping from registry
- `feed.xml/route.ts` — feed generation from registry
- `start-here/page.tsx` — collection getter resolution from registry

## Test plan
- [x] All 206 blakepetersen.io tests pass (27 suites)
- [x] Build completes successfully
- [x] New registry tests validate required fields, visibility helpers, and unknown slug errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)