### PR TITLE
feat(artax-ui): add type-safe theme token constants

### DIFF
--- a/packages/artax-ui/src/index.ts
+++ b/packages/artax-ui/src/index.ts
@@ -87,6 +87,8 @@ export {
   DropdownInteractiveLabel
 } from './components/organisms/dropdown/dropdown-interactive'
 export { cn } from './lib/utils'
+export { tokens } from './styles/tokens'
+export type { BgToken, TextToken, BorderToken, RingToken, FontToken } from './styles/tokens'
 export { mdxComponents } from './mdx/components'
 
 // Providers

--- a/packages/artax-ui/src/styles/tokens.ts
+++ b/packages/artax-ui/src/styles/tokens.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Type-safe Tailwind class constants derived from theme.css CSS custom properties.
+// ABOUTME: Organized by utility prefix (bg, text, border, ring, font) to match real component usage.
+
+export const tokens = {
+  bg: {
+    background: 'bg-background',
+    card: 'bg-card',
+    popover: 'bg-popover',
+    primary: 'bg-primary',
+    secondary: 'bg-secondary',
+    muted: 'bg-muted',
+    accent: 'bg-accent',
+    destructive: 'bg-destructive',
+    surfaceInfo: 'bg-surface-info',
+    surfaceWarning: 'bg-surface-warning',
+    surfaceSuccess: 'bg-surface-success',
+  },
+  text: {
+    foreground: 'text-foreground',
+    primary: 'text-primary',
+    primaryForeground: 'text-primary-foreground',
+    secondary: 'text-secondary',
+    secondaryForeground: 'text-secondary-foreground',
+    card: 'text-card',
+    cardForeground: 'text-card-foreground',
+    popover: 'text-popover',
+    popoverForeground: 'text-popover-foreground',
+    muted: 'text-muted',
+    mutedForeground: 'text-muted-foreground',
+    accent: 'text-accent',
+    accentForeground: 'text-accent-foreground',
+    destructive: 'text-destructive',
+    destructiveForeground: 'text-destructive-foreground',
+    success: 'text-success',
+    info: 'text-info',
+    warning: 'text-warning',
+  },
+  border: {
+    border: 'border-border',
+    input: 'border-input',
+    primary: 'border-primary',
+    destructive: 'border-destructive',
+    ring: 'border-ring',
+  },
+  ring: {
+    ring: 'ring-ring',
+    primary: 'ring-primary',
+  },
+  font: {
+    mono: 'font-mono',
+    monoAlt: 'font-mono-alt',
+    sans: 'font-sans',
+  },
+} as const
+
+export type BgToken = keyof typeof tokens.bg
+export type TextToken = keyof typeof tokens.text
+export type BorderToken = keyof typeof tokens.border
+export type RingToken = keyof typeof tokens.ring
+export type FontToken = keyof typeof tokens.font

--- a/packages/artax-ui/tests/tokens-sync.test.ts
+++ b/packages/artax-ui/tests/tokens-sync.test.ts
@@ -1,0 +1,140 @@
+// ABOUTME: Sync test verifying that tokens.ts entries correspond to CSS custom properties in theme.css.
+// ABOUTME: Catches drift between the TypeScript token map and the source-of-truth CSS file.
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { tokens } from '@/styles/tokens'
+
+const themeCss = readFileSync(
+  resolve(__dirname, '../src/styles/theme.css'),
+  'utf-8'
+)
+
+/** Convert a camelCase key to its kebab-case CSS custom property name. */
+function toCustomProperty(prefix: string, key: string): string {
+  const kebab = key.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`)
+  return `--${prefix}-${kebab}`
+}
+
+/** Convert a Tailwind class value to its CSS custom property name. */
+function valueToCssProperty(value: string): string {
+  // Strip the utility prefix (bg-, text-, border-, ring-, font-) to get the semantic name
+  const withoutPrefix = value.replace(/^(?:bg|text|border|ring|font)-/, '')
+  // Determine the CSS namespace from the value prefix
+  const cssPrefix = value.startsWith('font-') ? 'font' : 'color'
+  return `--${cssPrefix}-${withoutPrefix}`
+}
+
+/**
+ * Assert that a token value starts with the expected Tailwind prefix and that
+ * the CSS custom property derived from that value exists in theme.css.
+ */
+function expectValidToken(group: string, key: string, value: string): void {
+  // Value must start with the group prefix (e.g. bg-, text-, border-)
+  expect(value).toMatch(new RegExp(`^${group}-`))
+  // The CSS property derived from the value (not the key) must exist in theme.css
+  const cssProp = valueToCssProperty(value)
+  expect(themeCss).toContain(cssProp)
+}
+
+describe('tokens sync with theme.css', () => {
+  describe('bg tokens', () => {
+    it.each(Object.entries(tokens.bg))('%s maps to a valid --color-* property', (key, value) => {
+      expectValidToken('bg', key, value)
+    })
+  })
+
+  describe('text tokens', () => {
+    it.each(Object.entries(tokens.text))('%s maps to a valid --color-* property', (key, value) => {
+      expectValidToken('text', key, value)
+    })
+  })
+
+  describe('border tokens', () => {
+    it.each(Object.entries(tokens.border))('%s maps to a valid --color-* property', (key, value) => {
+      expectValidToken('border', key, value)
+    })
+  })
+
+  describe('ring tokens', () => {
+    it.each(Object.entries(tokens.ring))('%s maps to a valid --color-* property', (key, value) => {
+      expectValidToken('ring', key, value)
+    })
+  })
+
+  describe('font tokens', () => {
+    it.each(Object.entries(tokens.font))('%s maps to a valid --font-* property', (key, value) => {
+      expectValidToken('font', key, value)
+    })
+  })
+
+  describe('CSS → tokens (reverse sync)', () => {
+    /**
+     * CSS custom properties that are intentionally excluded from the token map.
+     * --radius-* properties are all set to 0px in the terminal aesthetic and
+     * are not exposed as utility tokens since components never need non-zero radii.
+     */
+    const INTENTIONALLY_EXCLUDED = new Set([
+      '--radius-sm',
+      '--radius-md',
+      '--radius-lg',
+      '--radius-xl',
+    ])
+
+    /** Build a flat set of CSS custom property names that tokens.ts maps to. */
+    function getAllTokenProperties(): Set<string> {
+      const props = new Set<string>()
+      for (const [group, entries] of Object.entries(tokens)) {
+        const prefix = group === 'font' ? 'font' : 'color'
+        for (const key of Object.keys(entries)) {
+          props.add(toCustomProperty(prefix, key))
+        }
+      }
+      return props
+    }
+
+    /** Extract all --color-*, --font-*, and --radius-* custom property definitions from theme.css. */
+    function getCssProperties(): string[] {
+      const matches = [...themeCss.matchAll(/^\s*(--(color|font|radius)-[\w-]+)\s*:/gm)]
+      return [...new Set(matches.map(m => m[1]))]
+    }
+
+    it('every --color-*, --font-*, and --radius-* CSS property has a corresponding token', () => {
+      const tokenProps = getAllTokenProperties()
+      const cssProps = getCssProperties()
+      const missing = cssProps.filter(p => !tokenProps.has(p) && !INTENTIONALLY_EXCLUDED.has(p))
+      expect(missing).toEqual([])
+    })
+  })
+
+  describe('Tailwind class format', () => {
+    it('bg tokens all start with bg-', () => {
+      for (const val of Object.values(tokens.bg)) {
+        expect(val).toMatch(/^bg-/)
+      }
+    })
+
+    it('text tokens all start with text-', () => {
+      for (const val of Object.values(tokens.text)) {
+        expect(val).toMatch(/^text-/)
+      }
+    })
+
+    it('border tokens all start with border-', () => {
+      for (const val of Object.values(tokens.border)) {
+        expect(val).toMatch(/^border-/)
+      }
+    })
+
+    it('ring tokens all start with ring-', () => {
+      for (const val of Object.values(tokens.ring)) {
+        expect(val).toMatch(/^ring-/)
+      }
+    })
+
+    it('font tokens all start with font-', () => {
+      for (const val of Object.values(tokens.font)) {
+        expect(val).toMatch(/^font-/)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Closes #85

- Creates `tokens.ts` with type-safe const mapping CSS custom properties to Tailwind utility classes
- Organized by usage pattern: `bg`, `text`, `border`, `ring`, `font`
- Includes all 25 color tokens + 3 font tokens (including surface-info/warning/success)
- Bidirectional sync test validates tokens↔theme.css correspondence
- Intentionally excludes `--radius-*` (all `0px` in terminal aesthetic) with documented rationale
- Exports types: `BgToken`, `TextToken`, `BorderToken`, `RingToken`, `FontToken`

Components are NOT migrated to use tokens yet — that's a gradual follow-up.

## Test plan
- [x] All 300 artax-ui tests pass (23 suites)
- [x] Forward sync: every token key maps to a real CSS custom property
- [x] Reverse sync: every CSS `--color-*`/`--font-*` property has a token entry
- [x] Barrel export includes tokens and all type exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)