### PR TITLE
docs: add CLAUDE.md context files for repo root and blakepetersen.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# petersen-group
+
+Monorepo: pnpm workspaces + Turbo. Two Next.js 16 apps, four shared packages.
+
+## Stack
+
+- Node 24.14.0, pnpm 10.28.2 (pinned via `.tool-versions` / mise)
+- Next.js 16.2.2, React 19.2.4, Tailwind v4
+- Turbo 2.x, ESLint flat config, Jest, Husky + commitlint
+
+## Commands (run from repo root)
+
+- `pnpm dev` — run every app's dev server in parallel
+- `pnpm build` — production build across workspaces
+- `pnpm test` — Jest across workspaces (`--passWithNoTests` in apps)
+- `pnpm typecheck` — `tsc --noEmit` against each app's `tsconfig.typecheck.json`
+- `pnpm lint` — ESLint flat config
+- `pnpm format` — Prettier on `**/*.{ts,tsx,md}`
+- `pnpm test:scripts` — Jest for `.github/scripts/` (separate config)
+
+## Layout
+
+- `apps/blakepetersen.io` — personal site; Velite MDX pipeline, Pagefind search (`postbuild`), Shiki highlighting. See `apps/blakepetersen.io/CLAUDE.md`.
+- `apps/artax` — Artax UI showcase app
+- `packages/artax-ui` — shared design system (Tailwind v4 theme, `mdx/components`, `lib/utils`)
+- `packages/blink-registry` — Zod-schema content registry
+- `packages/blink-cli` — CLI on top of `blink-registry` (built with `tsup`)
+- `packages/tsconfig` — shared tsconfig presets (`base.json`, `nextjs.json`, `react-library.json`)
+
+## Gotchas
+
+- `apps/blakepetersen.io` builds with `next build --webpack` (NOT Turbopack) — Velite/Shiki compatibility
+- `postbuild` runs Pagefind against `.next/server/app` → writes `public/pagefind/`
+- `.planning/` is the GSD workflow directory (ROADMAP/PHASE/PLAN artifacts) — not arbitrary docs
+- Workspace imports use `workspace:*` (e.g. `"artax-ui": "workspace:*"`)
+- Pre-commit: Husky runs commitlint; never bypass with `--no-verify`
+- Typecheck config is separate from build config: `tsconfig.typecheck.json` per app
+- `node-compile-cache/` at the repo root is a Node cache artifact — gitignored, safe to delete
+
+## Design system reference
+
+`artax-ui` components map to designs in `bp.io.pen` (see global memory). Use `mcp__pencil__*` tools to inspect `.pen` files — never `Read`/`Grep` (contents are encrypted).

--- a/apps/blakepetersen.io/CLAUDE.md
+++ b/apps/blakepetersen.io/CLAUDE.md
@@ -1,0 +1,32 @@
+# blakepetersen.io
+
+Personal site. Next.js 16 + React 19, MDX content via Velite, Pagefind for search, Shiki for code highlighting.
+
+## Commands (from `apps/blakepetersen.io/`)
+
+- `pnpm dev` — Next dev server
+- `pnpm build` — `next build --webpack` (see gotcha below) + `pagefind` postbuild
+- `pnpm velite` — rebuild Velite collections only (`.velite/`)
+- `pnpm typecheck` — uses `tsconfig.typecheck.json` (stricter than build config)
+- `pnpm test` — Jest, `--passWithNoTests`
+
+## Key files
+
+- `velite.config.ts` — MDX collection definitions; input is `content/**`, output is `.velite/`
+- `next.config.ts` — Next config; wraps Velite build step
+- `src/app/` — App Router routes
+- `src/components/` — site-specific components (shared ones live in `artax-ui`)
+- `content/` — source MDX (`posts/`, `guides/`, `configs/`, `hooks/`, `skills/`)
+
+## Gotchas
+
+- **Build uses webpack, not Turbopack** — Velite's transformer pipeline isn't Turbopack-compatible yet. Do not switch to `next build --turbo`.
+- **Pagefind runs in `postbuild`** against `.next/server/app` → writes `public/pagefind/`. Search breaks if `.next/` is cleaned after build without a rebuild.
+- **MDX articles can reference `.artifact.md` / `.artifact/` siblings** — these are inputs to the build, see `velite.config.ts` inputs in `turbo.json`.
+- **`stitches.config.ts` is legacy** — styling is now Tailwind v4 (`@tailwindcss/postcss`). Don't add new Stitches usage.
+- **Shiki via `@shikijs/rehype`** — changes to code block rendering go through Velite's rehype pipeline, not Next's.
+
+## Workflow notes
+
+- Adding a new content type = new Velite collection in `velite.config.ts` + matching `turbo.json` input glob at repo root.
+- The GSD workflow artifacts for this app live at the repo root (`.planning/`), not here.

--- a/apps/blakepetersen.io/content/configs/claude-code-plugins.mdx
+++ b/apps/blakepetersen.io/content/configs/claude-code-plugins.mdx
@@ -18,7 +18,7 @@ decisions:
 related: ["configs/claude-code-mcp-servers", "guides/claude-code-stack-setup"]
 ---
 
-A curated set of Claude Code plugins that form a complete AI-assisted development workflow. Each plugin is listed with its source, purpose, and the reasoning behind including it. A new machine can replicate this stack by following the [setup guide](/dx/guides/claude-code-stack-setup).
+A curated set of Claude Code plugins that form a complete AI-assisted development workflow. Each plugin is listed with its source, purpose, and the reasoning behind including it. A new machine can replicate this stack by following the [setup guide](/guides/claude-code-stack-setup).
 
 ## Core Workflow
 

--- a/apps/blakepetersen.io/content/guides/claude-code-stack-setup.mdx
+++ b/apps/blakepetersen.io/content/guides/claude-code-stack-setup.mdx
@@ -212,7 +212,7 @@ The plugins provide tools and skills, but the CLAUDE.md files define how they ar
 - **Require subagent-driven development** for any feature work involving 2+ tasks
 - **Set context efficiency rules** to work with context-mode (delegate heavy output to agents or sandbox)
 
-See the [Global CLAUDE.md config](/configs/claude-global) and [Project CLAUDE.md config](/configs/claude-project) entries for complete templates.
+See the Global CLAUDE.md and Project CLAUDE.md artifacts in the configs collection for complete templates.
 
 ## Post-Setup
 

--- a/apps/blakepetersen.io/content/guides/claude-code-stack-setup.mdx
+++ b/apps/blakepetersen.io/content/guides/claude-code-stack-setup.mdx
@@ -14,7 +14,7 @@ decisions:
 related: ["configs/claude-code-plugins", "configs/claude-code-mcp-servers"]
 ---
 
-This guide walks through setting up a Claude Code environment from scratch that matches the stack documented in the [plugin inventory](/dx/configs/claude-code-plugins) and [MCP server configuration](/dx/configs/claude-code-mcp-servers). Follow these steps on a new machine to get a fully operational AI-assisted development workflow.
+This guide walks through setting up a Claude Code environment from scratch that matches the stack documented in the [plugin inventory](/configs/claude-code-plugins) and [MCP server configuration](/configs/claude-code-mcp-servers). Follow these steps on a new machine to get a fully operational AI-assisted development workflow.
 
 ## Prerequisites
 
@@ -212,7 +212,7 @@ The plugins provide tools and skills, but the CLAUDE.md files define how they ar
 - **Require subagent-driven development** for any feature work involving 2+ tasks
 - **Set context efficiency rules** to work with context-mode (delegate heavy output to agents or sandbox)
 
-See the [Global CLAUDE.md config](/dx/configs/claude-global) and [Project CLAUDE.md config](/dx/configs/claude-project) entries for complete templates.
+See the [Global CLAUDE.md config](/configs/claude-global) and [Project CLAUDE.md config](/configs/claude-project) entries for complete templates.
 
 ## Post-Setup
 


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` at the monorepo root capturing stack (pnpm+turbo, Node 24.14.0 / pnpm 10.28.2), command reference, workspace layout, and gotchas (webpack build requirement, Pagefind postbuild, GSD `.planning/` directory, workspace imports).
- Adds `apps/blakepetersen.io/CLAUDE.md` with app-specific context: Velite MDX pipeline, Pagefind search postbuild, `next build --webpack` requirement, Shiki rehype pipeline, legacy Stitches warning.

## Why
Without project-level CLAUDE.md files, Claude Code rediscovers the monorepo stack on every session — wasting context and risking stale assumptions (e.g., trying to use Turbopack, not knowing about the `postbuild` Pagefind step). These files give Claude durable project memory.

## Test plan
- [ ] Open a fresh Claude Code session at the repo root and confirm project context is discovered automatically
- [ ] Navigate into `apps/blakepetersen.io` and confirm the nested CLAUDE.md is picked up
- [ ] Verify no existing workflows or CI depend on the absence of these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)