### PR TITLE
fix(site): restore Velite content dev loop + clipboard failure state (WS-3)

### DIFF
--- a/apps/blakepetersen.io/CLAUDE.md
+++ b/apps/blakepetersen.io/CLAUDE.md
@@ -4,7 +4,7 @@ Personal site. Next.js 16 + React 19, MDX content via Velite, Pagefind for searc
 
 ## Commands (from `apps/blakepetersen.io/`)
 
-- `pnpm dev` — Next dev server
+- `pnpm dev` — Next dev server (`next dev --webpack` — the VeliteWebpackPlugin only fires in the webpack hook, so Turbopack dev serves stale `.velite/` content)
 - `pnpm build` — `next build --webpack` (see gotcha below) + `pagefind` postbuild
 - `pnpm velite` — rebuild Velite collections only (`.velite/`)
 - `pnpm typecheck` — uses `tsconfig.typecheck.json` (stricter than build config)

--- a/apps/blakepetersen.io/next.config.ts
+++ b/apps/blakepetersen.io/next.config.ts
@@ -3,8 +3,6 @@
 
 import type { NextConfig } from 'next'
 
-const isDev = process.argv.indexOf('dev') !== -1
-
 const config: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ['artax-ui'],
@@ -18,20 +16,31 @@ const config: NextConfig = {
     ],
   },
   turbopack: {},
-  webpack(config) {
-    config.plugins.push(new VeliteWebpackPlugin())
+  webpack(config, { dev }) {
+    // `dev` comes from Next's webpack context — checking process.argv for
+    // 'dev' breaks in Next 16, where the config runs in a forked next-server
+    // worker with a rewritten argv (watch mode silently never started).
+    config.plugins.push(new VeliteWebpackPlugin(dev))
     return config
   },
 }
 
 class VeliteWebpackPlugin {
   static started = false
+  constructor(private readonly dev: boolean) {}
   apply(compiler: { hooks: { beforeCompile: { tapPromise: (name: string, fn: () => Promise<void>) => void } } }) {
     compiler.hooks.beforeCompile.tapPromise('VeliteWebpackPlugin', async () => {
       if (VeliteWebpackPlugin.started) return
       VeliteWebpackPlugin.started = true
       const { build } = await import('velite')
-      await build({ watch: isDev, clean: !isDev })
+      try {
+        await build({ watch: this.dev, clean: !this.dev })
+      } catch (err) {
+        // tapPromise rejections only surface when a page compiles — in dev
+        // that can be never, leaving a silent half-dead server. Log eagerly.
+        console.error('[VELITE] build failed:', err)
+        throw err
+      }
     })
   }
 }

--- a/apps/blakepetersen.io/package.json
+++ b/apps/blakepetersen.io/package.json
@@ -24,7 +24,7 @@
     "build": "next build --webpack",
     "postbuild": "pagefind --site .next/server/app --output-path public/pagefind",
     "clean": "rm -rf .next && rm -rf .turbo && rm -rf node_modules",
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "lint": "eslint .",
     "lint:content": "blink lint --content-root content",
     "migrate": "tsx scripts/migrate-content.ts",

--- a/apps/blakepetersen.io/src/app/install/[type]/[slug]/copy-command-block.tsx
+++ b/apps/blakepetersen.io/src/app/install/[type]/[slug]/copy-command-block.tsx
@@ -6,12 +6,20 @@
 import { useState } from 'react'
 
 export function CopyCommandBlock({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false)
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
+    'idle'
+  )
 
   async function handleCopy() {
-    await navigator.clipboard.writeText(command)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopyState('copied')
+    } catch {
+      // Clipboard access can be denied (permissions policy, insecure context);
+      // a mute button reads as broken, so surface the failure.
+      setCopyState('failed')
+    }
+    setTimeout(() => setCopyState('idle'), 2000)
   }
 
   return (
@@ -28,7 +36,11 @@ export function CopyCommandBlock({ command }: { command: string }) {
           onClick={handleCopy}
           className="shrink-0 rounded border border-border bg-background px-3 py-1.5 font-mono text-xs text-muted-foreground transition-colors hover:border-primary hover:text-primary"
         >
-          {copied ? 'copied!' : 'copy'}
+          {copyState === 'copied'
+            ? 'copied!'
+            : copyState === 'failed'
+              ? 'copy failed'
+              : 'copy'}
         </button>
       </div>
     </section>

--- a/apps/blakepetersen.io/tests/copy-command-block.test.tsx
+++ b/apps/blakepetersen.io/tests/copy-command-block.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+
+// ABOUTME: Tests for CopyCommandBlock clipboard interaction (WR-03).
+// ABOUTME: Covers success feedback and the denied-clipboard failure path.
+
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { CopyCommandBlock } from '@/app/install/[type]/[slug]/copy-command-block'
+
+function mockClipboard(writeText: jest.Mock) {
+  Object.assign(navigator, { clipboard: { writeText } })
+}
+
+describe('CopyCommandBlock', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('shows copied feedback when the clipboard write succeeds', async () => {
+    mockClipboard(jest.fn().mockResolvedValue(undefined))
+    render(<CopyCommandBlock command="blink apply skill/foo" />)
+
+    await act(async () => {
+      screen.getByRole('button').click()
+    })
+
+    expect(screen.getByRole('button')).toHaveTextContent('copied!')
+
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+    expect(screen.getByRole('button')).toHaveTextContent('copy')
+  })
+
+  it('shows failure feedback when the clipboard write is rejected', async () => {
+    mockClipboard(jest.fn().mockRejectedValue(new DOMException('denied')))
+    render(<CopyCommandBlock command="blink apply skill/foo" />)
+
+    await act(async () => {
+      screen.getByRole('button').click()
+    })
+
+    expect(screen.getByRole('button')).toHaveTextContent('copy failed')
+    expect(screen.getByRole('button')).not.toHaveTextContent('copied!')
+
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+    expect(screen.getByRole('button')).toHaveTextContent('copy')
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,8 @@ export default tseslint.config(
       '**/node_modules/**',
       '**/.turbo/**',
       '**/.next/**',
+      '**/.velite/**',
+      '**/.velite-fixture/**',
       '**/public/**',
       '**/dist/**',
       '.trash/**',


### PR DESCRIPTION
## Summary

Third audit workstream — kills the worst daily-friction bug: content edits were served stale until a manual `pnpm velite`, because the dev loop was broken by **two stacked bugs**:

1. `next dev` defaults to Turbopack in Next 16, which never calls the `webpack()` hook hosting `VeliteWebpackPlugin` → dev script now uses `--webpack` (matching build).
2. Even under webpack, `isDev` sniffed `process.argv` for `'dev'` — but Next 16 evaluates the config in a forked `next-server` worker with rewritten argv, so Velite always ran `watch: false`. Now uses the `dev` flag from the `webpack()` context.

Also in this slice:
- **Eager error logging** for Velite build failures — a `tapPromise` rejection only surfaces when a page compiles, so a failed content build (e.g. fresh clone missing `blink-registry/dist/`) looked like a silent hang at `building...`. Observed live while verifying.
- **WR-03**: `CopyCommandBlock` clipboard rejections no longer leave a mute button — transient `copy failed` state, with jsdom tests for both paths (TDD, red→green).
- **eslint**: ignore `.velite/` + `.velite-fixture/` — jest runs generate fixture `index.d.ts` files that added 6 project-service parsing errors, turning lint red locally after any test run.

**Scope cut:** the audit's prettier-enforcement item (CI `--check` + glob consistency) needs a whole-tree normalization commit first — deferred to backlog, filed in WS-13.

## Verification

- [x] Dev loop end-to-end: content edit → `[VELITE] changed: 'content/posts/…', rebuilding... → rebuild finished in 3.7s`
- [x] bp.io jest 43 suites / 284 tests green (incl. 2 new); typecheck clean; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)