### PR TITLE
fix(build): turbo task graph & cache correctness (WS-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
           node-version-file: '.tool-versions'
           cache: 'pnpm'
 
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm typecheck

--- a/apps/artax/package.json
+++ b/apps/artax/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "lint": "eslint .",
     "start": "next start",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {

--- a/apps/blakepetersen.io/CLAUDE.md
+++ b/apps/blakepetersen.io/CLAUDE.md
@@ -8,7 +8,7 @@ Personal site. Next.js 16 + React 19, MDX content via Velite, Pagefind for searc
 - `pnpm build` — `next build --webpack` (see gotcha below) + `pagefind` postbuild
 - `pnpm velite` — rebuild Velite collections only (`.velite/`)
 - `pnpm typecheck` — uses `tsconfig.typecheck.json` (stricter than build config)
-- `pnpm test` — Jest, `--passWithNoTests`
+- `pnpm test` — Jest (via turbo it builds this app first — registry-endpoint tests read `public/r/`)
 
 ## Key files
 
@@ -30,11 +30,11 @@ Personal site. Next.js 16 + React 19, MDX content via Velite, Pagefind for searc
 
 - **Build uses webpack, not Turbopack** — Velite's transformer pipeline isn't Turbopack-compatible yet. Do not switch to `next build --turbo`.
 - **Pagefind runs in `postbuild`** against `.next/server/app` → writes `public/pagefind/`. Search breaks if `.next/` is cleaned after build without a rebuild.
-- **MDX articles can reference `.artifact.md` / `.artifact/` siblings** — these are inputs to the build, see `velite.config.ts` inputs in `turbo.json`.
+- **MDX articles can reference `.artifact.md` / `.artifact/` siblings** — these are inputs to the build (turbo hashes all tracked package files by default).
 - **`stitches.config.ts` is legacy** — styling is now Tailwind v4 (`@tailwindcss/postcss`). Don't add new Stitches usage.
 - **Shiki via `@shikijs/rehype`** — changes to code block rendering go through Velite's rehype pipeline, not Next's.
 
 ## Workflow notes
 
-- Adding a new content type = new Velite collection in `velite.config.ts` + matching `turbo.json` input glob at repo root.
+- Adding a new content type = new Velite collection in `velite.config.ts` (turbo picks up new content files automatically — no input glob needed).
 - The GSD workflow artifacts for this app live at the repo root (`.planning/`), not here.

--- a/apps/blakepetersen.io/package.json
+++ b/apps/blakepetersen.io/package.json
@@ -30,7 +30,7 @@
     "migrate": "tsx scripts/migrate-content.ts",
     "perf:baseline": "tsx scripts/perf-baseline.ts",
     "start": "next start",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:visual": "playwright test tests/visual",
     "test:visual:update": "playwright test tests/visual --update-snapshots",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",

--- a/apps/blakepetersen.io/tests/registry-endpoints.test.ts
+++ b/apps/blakepetersen.io/tests/registry-endpoints.test.ts
@@ -15,11 +15,17 @@ const indexPath = join(registryDir, 'index.json')
 const registryExists = existsSync(indexPath)
 
 describe('Registry Endpoints (REG-02/03/04/05)', () => {
-  const skipReason = registryExists
-    ? undefined
-    : 'public/r/index.json not found — run pnpm build first'
+  // A missing registry used to test.skip the whole contract, so a build that
+  // stopped emitting public/r/ still produced a green test run. Turbo now
+  // builds this app before its tests (blakepetersen.io#test dependsOn build);
+  // if the registry is absent, that's a real failure worth hearing about.
+  if (!registryExists) {
+    throw new Error(
+      'public/r/index.json not found — run `pnpm build` (or `pnpm test` via turbo, which builds first) before the registry endpoint tests'
+    )
+  }
 
-  const conditionalTest = skipReason ? test.skip : test
+  const conditionalTest = test
 
   conditionalTest('index.json exists and is valid JSON', () => {
     const raw = readFileSync(indexPath, 'utf-8')

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -27,6 +27,11 @@ export default {
   // `blink lint --content-root content` is currently buggy (reports phantom
   // frontmatter-schema errors on .artifact.md siblings). Calling `blink lint`
   // without the flag lets it auto-detect content and reports cleanly.
-  'apps/blakepetersen.io/content/**/*.{mdx,md}': () =>
-    `pnpm --filter blakepetersen.io exec blink lint`,
+  // The CLI bin resolves to packages/blink-cli/dist/, which doesn't exist on
+  // a fresh clone — build it first (tsup, sub-second when warm) so the hook
+  // fails on real lint errors rather than a missing binary.
+  'apps/blakepetersen.io/content/**/*.{mdx,md}': () => [
+    'pnpm --filter @blink/cli build',
+    'pnpm --filter blakepetersen.io exec blink lint',
+  ],
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,14 +3,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": [
-        "src/**",
-        "content/**/*.mdx",
-        "content/**/*.artifact.md",
-        "content/**/*.artifact/**",
-        "velite.config.ts"
-      ],
-      "outputs": [".next/**", "dist/**", ".velite/**"]
+      "outputs": [
+        ".next/**",
+        "dist/**",
+        ".velite/**",
+        "public/pagefind/**",
+        "public/r/**"
+      ]
     },
     "clean": {
       "cache": false
@@ -25,9 +24,15 @@
       "outputs": []
     },
     "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "blakepetersen.io#test": {
+      "dependsOn": ["build"],
       "outputs": []
     },
     "typecheck": {
+      "dependsOn": ["^build"],
       "outputs": []
     }
   }


### PR DESCRIPTION
## Summary

Second audit workstream — the task graph was wrong in three compounding ways, all fixed and verified locally:

- **Cache-hit deploys were broken**: build `outputs` omitted `public/pagefind/**` and `public/r/**`, so any warm cache hit shipped without the search index or registry endpoints. Verified the fix by deleting both and rebuilding — `FULL TURBO` (312ms) restores them from cache.
- **Stale-hit landmine**: custom build `inputs` replaced turbo's default hash, so `next.config.ts`/postcss/tsup/package.json edits could reuse stale artifacts. Removed — default hashing covers everything the list attempted.
- **Ordering-dependent green**: `test`/`typecheck` had no `dependsOn` and passed only because CI happens to build first; fresh clones failed on missing `blink-registry/dist/` (reproduced live in a fresh worktree during WS-3). Now `^build`, plus `blakepetersen.io#test → build` since the registry-endpoint tests read `public/r/`.

Consequences wired through:
- `registry-endpoints.test.ts` silent `test.skip` → loud failure (the graph now guarantees the registry exists; its absence is a real defect)
- `--passWithNoTests` dropped from both apps (both have real suites)
- CI caches `.turbo` (safe only now that outputs are complete)
- pre-commit content lint builds `@blink/cli` first instead of failing on a missing binary
- CLAUDE.md input-glob guidance updated

## Verification

- [x] Cold build → warm rebuild: `4 cached, FULL TURBO`, pagefind + registry restored
- [x] `pnpm test` through the new graph: 5 workspaces green, registry suite **runs** (`PASS tests/registry-endpoints.test.ts`)
- [x] `pnpm typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)