### PR TITLE
fix(cli): content lint gate, end-to-end (WS-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - run: pnpm build
       - run: pnpm typecheck
       - run: pnpm lint
+      - run: pnpm lint:content
       - run: pnpm test
       - run: pnpm test:scripts
 

--- a/apps/blakepetersen.io/CLAUDE.md
+++ b/apps/blakepetersen.io/CLAUDE.md
@@ -25,6 +25,7 @@ Personal site. Next.js 16 + React 19, MDX content via Velite, Pagefind for searc
 
 - Consumes `artax-ui` (design system) via `workspace:*`
 - Imports types only from `blink-registry` (e.g. `ArtifactMetadata` in `src/lib/artifacts.ts`); the registry's runtime/Zod usage lives in `@blink/cli`, not here
+- Dev-depends on `@blink/cli` so the `blink` bin (used by `lint:content` and the pre-commit hook) resolves deterministically
 
 ## Gotchas
 

--- a/apps/blakepetersen.io/package.json
+++ b/apps/blakepetersen.io/package.json
@@ -37,6 +37,7 @@
     "velite": "velite build"
   },
   "devDependencies": {
+    "@blink/cli": "workspace:*",
     "@dagrejs/dagre": "^3.0.0",
     "@playwright/test": "^1.59.1",
     "@types/jest": "^30.0.0",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -24,14 +24,14 @@ export default {
     const filtered = files.filter((f) => !f.includes('/apps/luna/'))
     return filtered.length ? `fallow dead-code --quiet ${fileFlags(filtered)}` : []
   },
-  // `blink lint --content-root content` is currently buggy (reports phantom
-  // frontmatter-schema errors on .artifact.md siblings). Calling `blink lint`
-  // without the flag lets it auto-detect content and reports cleanly.
+  // Staged-only content lint (LINT-05). The runner dispatches by collection,
+  // so posts and .artifact.md siblings passed here are filtered, not
+  // mis-validated against the DX schema (the old "phantom errors").
   // The CLI bin resolves to packages/blink-cli/dist/, which doesn't exist on
   // a fresh clone — build it first (tsup, sub-second when warm) so the hook
   // fails on real lint errors rather than a missing binary.
-  'apps/blakepetersen.io/content/**/*.{mdx,md}': () => [
+  'apps/blakepetersen.io/content/**/*.{mdx,md}': (files) => [
     'pnpm --filter @blink/cli build',
-    'pnpm --filter blakepetersen.io exec blink lint',
+    `pnpm --filter blakepetersen.io exec blink lint --files ${files.join(',')}`,
   ],
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "dev": "turbo run dev --filter=!Luna",
     "lint": "turbo run lint --filter=!Luna",
+    "lint:content": "turbo run lint:content --filter=!Luna",
     "test": "turbo run test --filter=!Luna",
     "typecheck": "turbo run typecheck --filter=!Luna",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/blink-cli/src/commands/lint.ts
+++ b/packages/blink-cli/src/commands/lint.ts
@@ -1,10 +1,23 @@
 // ABOUTME: CLI command for content linting (frontmatter schema, artifact-pair, voice primitives).
 // ABOUTME: Reports ESLint-style output. Exits non-zero on errors, exit 0 on warnings-only per D-06.
 
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { defineCommand } from 'citty'
 import { consola } from 'consola'
 import { runLint } from '@/lint/runner'
 import { formatDiagnostics } from '@/lint/reporter'
+
+/**
+ * The command runs from the app dir (lint-staged, package scripts) or the
+ * monorepo root (CI) — a fixed relative default silently pointed at a
+ * nonexistent directory in one of the two, which the runner used to treat
+ * as a clean run. Prefer `content/` beside the cwd, else the monorepo path.
+ */
+function defaultContentRoot(): string {
+  if (existsSync(join(process.cwd(), 'content'))) return 'content'
+  return 'apps/blakepetersen.io/content'
+}
 
 export default defineCommand({
   meta: {
@@ -24,12 +37,13 @@ export default defineCommand({
     },
     'content-root': {
       type: 'string',
-      description: 'Path to content directory',
-      default: 'apps/blakepetersen.io/content',
+      description:
+        'Path to content directory (default: ./content if present, else apps/blakepetersen.io/content)',
+      required: false,
     },
   },
   async run({ args }) {
-    const contentRoot = args['content-root'] as string
+    const contentRoot = (args['content-root'] as string) || defaultContentRoot()
     const parsedFiles = args.files
       ? (args.files as string).split(',').map((f) => f.trim())
       : undefined

--- a/packages/blink-cli/src/lint/rules/no-inline-artifact-body.ts
+++ b/packages/blink-cli/src/lint/rules/no-inline-artifact-body.ts
@@ -1,0 +1,24 @@
+// ABOUTME: LINT-06 — forbids direct <ArtifactBody> invocation in MDX bodies.
+// ABOUTME: The install route is the sole render path (Variant 3); inline use silently renders nothing.
+
+import type { LintDiagnostic, LintRule, LintContext } from '@/lint/types'
+
+const INLINE_ARTIFACT_BODY_PATTERN = /<ArtifactBody[\s/>]/
+
+export const noInlineArtifactBodyRule: LintRule = {
+  name: 'no-inline-artifact-body',
+
+  check(ctx: LintContext): LintDiagnostic[] {
+    if (!INLINE_ARTIFACT_BODY_PATTERN.test(ctx.body)) return []
+
+    return [
+      {
+        file: ctx.file,
+        severity: 'error',
+        rule: 'no-inline-artifact-body',
+        message:
+          '<ArtifactBody> is not registered in mdxComponents and renders nothing from MDX — link to the /install route instead',
+      },
+    ]
+  },
+}

--- a/packages/blink-cli/src/lint/rules/voice-primitive.ts
+++ b/packages/blink-cli/src/lint/rules/voice-primitive.ts
@@ -1,5 +1,5 @@
 // ABOUTME: LINT-03 — checks voice-primitive invocation in MDX body matches voice[] frontmatter.
-// ABOUTME: All diagnostics are warnings (advisory) per v1.4-PLAN-06 / LINT-07.
+// ABOUTME: Declared-but-uninvoked is an error (promoted on a 20/20 organic pass rate); heading advisory stays warning.
 
 import type { LintDiagnostic, LintRule, LintContext } from '@/lint/types'
 
@@ -25,7 +25,7 @@ export const voicePrimitiveRule: LintRule = {
       if (!mapping.pattern.test(ctx.body)) {
         diagnostics.push({
           file: ctx.file,
-          severity: 'warning',
+          severity: 'error',
           rule: 'voice-primitive',
           message: `voice '${value}' declared but <${mapping.component}> not found in body`,
         })

--- a/packages/blink-cli/src/lint/runner.ts
+++ b/packages/blink-cli/src/lint/runner.ts
@@ -2,11 +2,13 @@
 // ABOUTME: Supports both full-tree scan and --files mode for staged-only lint (LINT-05).
 
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, relative, resolve, sep } from 'node:path'
 import matter from 'gray-matter'
+import { DX_COLLECTIONS } from 'blink-registry'
 import { frontmatterSchemaRule } from '@/lint/rules/frontmatter-schema'
 import { artifactPairRule } from '@/lint/rules/artifact-pair'
 import { voicePrimitiveRule } from '@/lint/rules/voice-primitive'
+import { noInlineArtifactBodyRule } from '@/lint/rules/no-inline-artifact-body'
 import type { LintDiagnostic, LintContext, LintRule } from '@/lint/types'
 
 export interface LintOptions {
@@ -22,7 +24,27 @@ export interface LintResult {
   warningCount: number
 }
 
-const rules: LintRule[] = [frontmatterSchemaRule, artifactPairRule, voicePrimitiveRule]
+const rules: LintRule[] = [
+  frontmatterSchemaRule,
+  artifactPairRule,
+  voicePrimitiveRule,
+  noInlineArtifactBodyRule,
+]
+
+/**
+ * Lint targets are `.mdx` entries inside DX collections. `posts/` (and any
+ * future non-DX collection) has its own schema in velite.config.ts — running
+ * the DX frontmatter schema against it produced 2 false errors per post.
+ * `.artifact.md` siblings are validated transitively via the artifact-pair
+ * rule on their parent entry, never as standalone lint targets.
+ */
+function isDxEntry(contentRoot: string, file: string): boolean {
+  if (!file.endsWith('.mdx')) return false
+  const rel = relative(resolve(contentRoot), resolve(file))
+  if (rel.startsWith('..')) return false
+  const collection = rel.split(sep)[0]
+  return (DX_COLLECTIONS as readonly string[]).includes(collection)
+}
 
 function discoverMdxFiles(dir: string): string[] {
   const files: string[] = []
@@ -60,7 +82,28 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   const diagnostics: LintDiagnostic[] = []
   const fixed: string[] = []
 
-  const mdxFiles = specifiedFiles ?? discoverMdxFiles(contentRoot)
+  const candidates = specifiedFiles ?? discoverMdxFiles(contentRoot)
+  const mdxFiles = candidates.filter((f) => isDxEntry(contentRoot, f))
+
+  // A missing or empty content root must never read as a clean run — that
+  // exact silence let the pre-commit gate no-op for a whole phase. Explicit
+  // --files selections may legitimately filter to nothing (e.g. a commit
+  // touching only posts), so only full-tree scans get this guard.
+  if (!specifiedFiles && mdxFiles.length === 0) {
+    return {
+      diagnostics: [
+        {
+          file: contentRoot,
+          severity: 'error',
+          rule: 'content-root',
+          message: `no lintable DX entries found under '${contentRoot}' — wrong --content-root?`,
+        },
+      ],
+      fixed: [],
+      errorCount: 1,
+      warningCount: 0,
+    }
+  }
 
   for (const file of mdxFiles) {
     let content: string
@@ -117,9 +160,13 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     }
   }
 
-  // Run orphan scan
-  const orphanDiagnostics = artifactPairRule.checkOrphans(contentRoot)
-  diagnostics.push(...orphanDiagnostics)
+  // Orphan scan sweeps the whole tree — full-tree runs only. In --files mode
+  // (staged-only lint per LINT-05) it would report pre-existing orphans
+  // unrelated to the commit being checked.
+  if (!specifiedFiles) {
+    const orphanDiagnostics = artifactPairRule.checkOrphans(contentRoot)
+    diagnostics.push(...orphanDiagnostics)
+  }
 
   const errorCount = diagnostics.filter((d) => d.severity === 'error').length
   const warningCount = diagnostics.filter((d) => d.severity === 'warning').length

--- a/packages/blink-cli/tests/lint/reporter.test.ts
+++ b/packages/blink-cli/tests/lint/reporter.test.ts
@@ -61,8 +61,11 @@ describe('formatDiagnostics', () => {
     const { tmpdir } = await import('node:os')
 
     const dir = mkdtempSync(join(tmpdir(), 'blink-lint-runner-'))
+    // Lint targets live inside DX collections — files at the content root
+    // are not dispatched to any schema.
+    mkdirSync(join(dir, 'skills'))
     writeFileSync(
-      join(dir, 'valid.mdx'),
+      join(dir, 'skills', 'valid.mdx'),
       [
         '---',
         'title: Valid Skill',
@@ -84,13 +87,14 @@ describe('formatDiagnostics', () => {
 
   it('runLint on directory with invalid MDX returns frontmatter-schema error', async () => {
     const { runLint } = await import('@/lint/runner')
-    const { mkdtempSync, writeFileSync } = await import('node:fs')
+    const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs')
     const { join } = await import('node:path')
     const { tmpdir } = await import('node:os')
 
     const dir = mkdtempSync(join(tmpdir(), 'blink-lint-runner-'))
+    mkdirSync(join(dir, 'skills'))
     writeFileSync(
-      join(dir, 'invalid.mdx'),
+      join(dir, 'skills', 'invalid.mdx'),
       [
         '---',
         'description: Missing title field.',

--- a/packages/blink-cli/tests/lint/rules/voice-primitive.test.ts
+++ b/packages/blink-cli/tests/lint/rules/voice-primitive.test.ts
@@ -25,26 +25,26 @@ describe('voicePrimitiveRule', () => {
     expect(diagnostics).toEqual([])
   })
 
-  it('warning when voice=[author-note] but body does NOT contain <AuthorNote', () => {
+  it('error when voice=[author-note] but body does NOT contain <AuthorNote', () => {
     const ctx = makeContext(
       { voice: ['author-note'] },
       '## Overview\n\nNo author note here.',
     )
     const diagnostics = voicePrimitiveRule.check(ctx)
     expect(diagnostics.length).toBe(1)
-    expect(diagnostics[0].severity).toBe('warning')
+    expect(diagnostics[0].severity).toBe('error')
     expect(diagnostics[0].message).toContain('author-note')
     expect(diagnostics[0].message).toContain('AuthorNote')
   })
 
-  it('warning when voice=[decision-rationale] but body does NOT contain <DecisionRationale', () => {
+  it('error when voice=[decision-rationale] but body does NOT contain <DecisionRationale', () => {
     const ctx = makeContext(
       { voice: ['decision-rationale'] },
       '## Overview\n\nNo rationale component.',
     )
     const diagnostics = voicePrimitiveRule.check(ctx)
     expect(diagnostics.length).toBe(1)
-    expect(diagnostics[0].severity).toBe('warning')
+    expect(diagnostics[0].severity).toBe('error')
     expect(diagnostics[0].message).toContain('decision-rationale')
     expect(diagnostics[0].message).toContain('DecisionRationale')
   })
@@ -76,16 +76,24 @@ describe('voicePrimitiveRule', () => {
     expect(diagnostics[0].message).toContain('heading')
   })
 
-  it('all voice-primitive diagnostics have severity warning (NOT error)', () => {
+  it('declared-but-uninvoked diagnostics are errors; the heading advisory stays a warning', () => {
+    // LINT-03 promoted warn→error per the Phase 29 delta report (20/20
+    // organic invocation rate). The rationale-heading nudge remains advisory.
     const ctx = makeContext(
       { voice: ['author-note', 'decision-rationale'] },
       '## Overview\n\nNo components at all.',
     )
     const diagnostics = voicePrimitiveRule.check(ctx)
     expect(diagnostics.length).toBeGreaterThan(0)
-    for (const d of diagnostics) {
-      expect(d.severity).toBe('warning')
+    for (const d of diagnostics.filter((x) => x.message.includes('declared but'))) {
+      expect(d.severity).toBe('error')
     }
+
+    const advisory = voicePrimitiveRule.check(
+      makeContext({ voice: [] }, '## Why\n\nBecause.'),
+    )
+    expect(advisory.length).toBe(1)
+    expect(advisory[0].severity).toBe('warning')
   })
 
   it('fix mode adds missing voice value when rationale-shaped heading detected', () => {

--- a/packages/blink-cli/tests/lint/runner.test.ts
+++ b/packages/blink-cli/tests/lint/runner.test.ts
@@ -1,0 +1,209 @@
+// ABOUTME: Tests for the lint runner — collection dispatch, discovery, and rule severity.
+// ABOUTME: Guards the CI-gate contract: DX collections lint, posts don't, silence is never green.
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runLint } from '@/lint/runner'
+
+const VALID_DX_FRONTMATTER = `---
+title: Test Skill
+description: A test skill entry
+applies_to:
+  - typescript
+---
+
+Some body content.
+`
+
+const POST_FRONTMATTER = `---
+title: A blog post
+date: 2026-01-01
+summary: Posts use a different schema entirely
+---
+
+Blog prose.
+`
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'blink-lint-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function write(rel: string, content: string): string {
+  const full = join(root, rel)
+  mkdirSync(join(full, '..'), { recursive: true })
+  writeFileSync(full, content, 'utf-8')
+  return full
+}
+
+describe('collection dispatch', () => {
+  it('does not lint files outside DX collections (posts get their own schema elsewhere)', async () => {
+    write('skills/good.mdx', VALID_DX_FRONTMATTER)
+    write('posts/blog-entry.mdx', POST_FRONTMATTER)
+
+    const result = await runLint({ contentRoot: root })
+
+    const postDiagnostics = result.diagnostics.filter((d) =>
+      d.file.includes('posts/')
+    )
+    expect(postDiagnostics).toEqual([])
+    expect(result.errorCount).toBe(0)
+  })
+
+  it('still validates DX collection files against the DX schema', async () => {
+    write('skills/bad.mdx', `---\ntitle: Missing everything else\n---\n\nBody.\n`)
+
+    const result = await runLint({ contentRoot: root })
+
+    expect(result.errorCount).toBeGreaterThan(0)
+    expect(
+      result.diagnostics.some((d) => d.rule === 'frontmatter-schema')
+    ).toBe(true)
+  })
+
+  it('filters --files input to DX-collection .mdx entries', async () => {
+    const post = write('posts/blog-entry.mdx', POST_FRONTMATTER)
+    const artifact = write('skills/good.artifact.md', 'body payload')
+    const skill = write(
+      'skills/bad.mdx',
+      `---\ntitle: Missing fields\n---\n\nBody.\n`
+    )
+
+    const result = await runLint({
+      contentRoot: root,
+      files: [post, artifact, skill],
+    })
+
+    expect(
+      result.diagnostics.every((d) => d.file === skill)
+    ).toBe(true)
+    expect(result.errorCount).toBeGreaterThan(0)
+  })
+})
+
+describe('discovery safety', () => {
+  it('errors loudly when the content root does not exist', async () => {
+    const result = await runLint({ contentRoot: join(root, 'nope') })
+
+    expect(result.errorCount).toBeGreaterThan(0)
+    expect(
+      result.diagnostics.some((d) => d.rule === 'content-root')
+    ).toBe(true)
+  })
+
+  it('errors loudly when the content root contains no lintable files', async () => {
+    // An existing-but-empty root is the silent-no-op failure mode that let
+    // the pre-commit gate rot — it must never produce a green run.
+    const result = await runLint({ contentRoot: root })
+
+    expect(result.errorCount).toBeGreaterThan(0)
+    expect(
+      result.diagnostics.some((d) => d.rule === 'content-root')
+    ).toBe(true)
+  })
+})
+
+describe('voice-primitive promotion (LINT-03)', () => {
+  it('reports declared-but-uninvoked voice primitives as errors', async () => {
+    write(
+      'skills/voiced.mdx',
+      `---
+title: Voiced entry
+description: Declares author-note but never invokes it
+applies_to:
+  - typescript
+voice:
+  - author-note
+---
+
+No component here.
+`
+    )
+
+    const result = await runLint({ contentRoot: root })
+
+    const voiceDiag = result.diagnostics.find(
+      (d) => d.rule === 'voice-primitive' && d.message.includes('author-note')
+    )
+    expect(voiceDiag).toBeDefined()
+    expect(voiceDiag?.severity).toBe('error')
+  })
+
+  it('keeps the rationale-shaped-heading advisory at warning severity', async () => {
+    write(
+      'skills/advisory.mdx',
+      `---
+title: Advisory entry
+description: Has a rationale-looking heading, no voice declared
+applies_to:
+  - typescript
+---
+
+## Why I chose pnpm
+
+Because reasons.
+`
+    )
+
+    const result = await runLint({ contentRoot: root })
+
+    const advisory = result.diagnostics.find(
+      (d) => d.rule === 'voice-primitive' && d.message.includes('heading')
+    )
+    if (advisory) {
+      expect(advisory.severity).toBe('warning')
+    }
+  })
+})
+
+describe('no-inline-artifact-body rule', () => {
+  it('errors when an MDX body invokes <ArtifactBody> directly', async () => {
+    write(
+      'skills/inline.mdx',
+      `---
+title: Inline artifact body
+description: Violates the Variant 3 invariant
+applies_to:
+  - typescript
+---
+
+<ArtifactBody slug="skills/inline" />
+`
+    )
+
+    const result = await runLint({ contentRoot: root })
+
+    const diag = result.diagnostics.find(
+      (d) => d.rule === 'no-inline-artifact-body'
+    )
+    expect(diag).toBeDefined()
+    expect(diag?.severity).toBe('error')
+  })
+
+  it('does not fire on entries that merely link to the install route', async () => {
+    write(
+      'skills/linked.mdx',
+      `---
+title: Linked entry
+description: Uses the install route as intended
+applies_to:
+  - typescript
+---
+
+<a href="/install/skills/linked" target="_blank" rel="noopener">Install</a>
+`
+    )
+
+    const result = await runLint({ contentRoot: root })
+
+    expect(
+      result.diagnostics.some((d) => d.rule === 'no-inline-artifact-body')
+    ).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
     devDependencies:
+      '@blink/cli':
+        specifier: workspace:*
+        version: link:../../packages/blink-cli
       '@dagrejs/dagre':
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
## Summary

Fourth audit workstream. The investigation found the gate wasn't just unwired — **it has never once been real**, due to four stacked failures that concealed each other:

1. **Schema dispatch bug**: the runner linted every `.mdx` under the content root against the DX frontmatter schema. `posts/` has its own schema, so full-tree lint always showed 24 false errors. These were the 'phantom errors' blamed on the `--content-root` flag in c3af43e.
2. **The 'fix' made it a no-op**: removing the flag made the default root resolve to a nonexistent path from the app dir — and `discoverMdxFiles` swallows the readdir failure, so the hook linted *nothing* and reported clean.
3. **Bin resolution by accident**: `blakepetersen.io` never depended on `@blink/cli`; `blink` resolved only via hoisting luck (fresh worktree: `command not found`).
4. **No CI step** (Phase 28 SC3 marked wired, wasn't).

All four fixed, plus the two rule changes the gate unblocks:
- **LINT-03 promoted warn→error** — the delta report recommended PROMOTE for Phase 30; landing early because full-tree lint against live content proves 0 errors (20/20 organic invocation rate held)
- **New `no-inline-artifact-body` rule** (error) — closes the Integration-Check Flow 3 defense-in-depth gap (Variant 3 invariant was convention-only)
- Empty/missing content root is now a hard `content-root` error — silence can never again read as green
- Orphan scan scoped to full-tree runs (staged-only `--files` semantics per LINT-05)
- Pre-commit restored to fast staged-only `--files` mode; `pnpm lint:content` runs in CI after `pnpm lint`

## Verification

- [x] TDD: 9 new runner tests (dispatch, discovery safety, promotion, new rule) red→green; blink-cli 271/271
- [x] Full-tree lint vs live content: **0 errors, 5 known warnings**, exit 0 (D-06)
- [x] `--files` with mixed post/artifact/skill inputs filters correctly; app-dir default auto-detects
- [x] Full sweep: build, typecheck, lint, lint:content, test — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)