### PR TITLE
fix(site): registry pipeline correctness (WS-5)

### DIFF
--- a/apps/blakepetersen.io/src/lib/git-history.ts
+++ b/apps/blakepetersen.io/src/lib/git-history.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Git history extraction and content freshness label computation.
 // ABOUTME: Provides build-time git log queries and pure functions for freshness display.
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 
 type GitHistory = {
   lastModified: string
@@ -12,26 +12,35 @@ type GitHistory = {
  * Extracts git history for a file path. Uses --follow to track renames.
  * Returns fallback values if git commands fail.
  */
+function fallbackHistory(filePath: string, reason: string): GitHistory {
+  // Shallow clones and non-git checkouts land here. The fabricated value
+  // labels the entry "New (today)" — say so instead of lying silently.
+  console.warn(
+    `[git-history] no history for ${filePath} (${reason}) — using fallback freshness (today, 1 commit)`,
+  )
+  return { lastModified: new Date().toISOString(), commitCount: 1 }
+}
+
 export function getGitHistoryForFile(filePath: string): GitHistory {
   try {
-    const lastModified = execSync(
-      `git log -1 --follow --format=%cI -- "${filePath}"`,
+    // One dated line per commit: first line is lastModified, line count is
+    // commitCount — a single subprocess per file (was two plus a shell pipe).
+    const dates = execFileSync(
+      'git',
+      ['log', '--follow', '--format=%cI', '--', filePath],
       { encoding: 'utf-8' },
-    ).trim()
+    )
+      .trim()
+      .split('\n')
+      .filter(Boolean)
 
-    const commitCountOutput = execSync(
-      `git log --follow --oneline -- "${filePath}" | wc -l`,
-      { encoding: 'utf-8', shell: '/bin/sh' },
-    ).trim()
-    const commitCount = parseInt(commitCountOutput, 10)
-
-    if (!lastModified || isNaN(commitCount)) {
-      return { lastModified: new Date().toISOString(), commitCount: 1 }
+    if (dates.length === 0) {
+      return fallbackHistory(filePath, 'no commits found')
     }
 
-    return { lastModified, commitCount }
-  } catch {
-    return { lastModified: new Date().toISOString(), commitCount: 1 }
+    return { lastModified: dates[0], commitCount: dates.length }
+  } catch (err) {
+    return fallbackHistory(filePath, err instanceof Error ? err.message : 'git failed')
   }
 }
 

--- a/apps/blakepetersen.io/src/lib/velite-prepare.ts
+++ b/apps/blakepetersen.io/src/lib/velite-prepare.ts
@@ -38,6 +38,7 @@ export type DxItem = {
 export type PostItem = {
   slug: string
   draft?: boolean
+  related: string[]
 }
 
 type SingleArtifactInput = {
@@ -76,6 +77,8 @@ export type ValidatedArtifact = {
   type: string
   version: string
   description: string
+  /** Full content path (e.g. 'skills/claude-code/writing-custom-skills') — the site route. */
+  pagePath: string
   files: Array<{ path: string; content: string; merge: string }>
   devDependencies?: Record<string, string>
 }
@@ -142,10 +145,31 @@ export function validateCrossReferences(data: DxData): void {
     }
   }
 
+  // Posts' `related` refs may target DX entries or other posts; they used to
+  // bypass validation entirely and silently drop at render time.
+  const postSlugs = new Set(data.posts.map((p) => p.slug))
+  for (const post of data.posts) {
+    for (const ref of post.related) {
+      const coll = ref.slice(0, ref.indexOf('/'))
+      const known =
+        coll === 'posts'
+          ? postSlugs.has(ref)
+          : coll in collectionSlugs &&
+            collectionSlugs[coll as DxCollectionName].has(ref)
+      if (!known) {
+        brokenRefs.push(`  ${post.slug} related: '${ref}' — target not found`)
+      }
+    }
+  }
+
   if (brokenRefs.length > 0) {
-    throw new Error(
-      `Broken cross-references in DX content (${brokenRefs.length}):\n${brokenRefs.join('\n')}`,
+    const error = new Error(
+      `Broken cross-references in content (${brokenRefs.length}):\n${brokenRefs.join('\n')}`,
     )
+    // Stable name for error tracking — a bare Error from inside Velite's
+    // prepare hook is indistinguishable from any other build failure.
+    error.name = 'BlinkCrossRefError'
+    throw error
   }
 }
 
@@ -217,12 +241,14 @@ export function extractGitHistory(
 
 type VersionManifest = Record<string, { hash: string; version: string }>
 
-function deriveArtifactSlug(velitePath: string): string {
-  const cleaned = velitePath
+function deriveArtifactPaths(velitePath: string): { slug: string; pagePath: string } {
+  const pagePath = velitePath
     .replace(/\.artifact\/manifest$/, '')
     .replace(/\.artifact$/, '')
-  // Extract just the filename portion to produce a valid slug (no slashes)
-  return cleaned.split('/').pop() || cleaned
+  // Slug is the filename portion (SlugSchema forbids slashes); the full
+  // pagePath is kept separately — registry URLs built from `<type>s/<slug>`
+  // 404'd for every entry nested below its collection root.
+  return { slug: pagePath.split('/').pop() || pagePath, pagePath }
 }
 
 function sha256Hex(payload: string): string {
@@ -240,14 +266,24 @@ export function versionAndValidateArtifacts(
   contentDir: string,
 ): ValidatedArtifact[] {
   const versionManifestPath = path.resolve(contentDir, '.artifact-versions.json')
-  const priorVersionManifest: VersionManifest = fs.existsSync(versionManifestPath)
-    ? JSON.parse(fs.readFileSync(versionManifestPath, 'utf-8'))
-    : {}
+  let priorVersionManifest: VersionManifest = {}
+  if (fs.existsSync(versionManifestPath)) {
+    try {
+      priorVersionManifest = JSON.parse(fs.readFileSync(versionManifestPath, 'utf-8'))
+    } catch (cause) {
+      // Merge conflicts are the usual culprit — a raw SyntaxError from inside
+      // Velite's prepare hook gave no path and no recovery step.
+      throw new Error(
+        `Version manifest corrupted at ${versionManifestPath} — fix or delete it to regenerate (versions will re-derive from git dates)`,
+        { cause },
+      )
+    }
+  }
   const updatedVersionManifest: VersionManifest = {}
   const dateCounters = new Map<string, number>()
 
   const singles: ValidatedArtifact[] = data.singleArtifacts.map((artifact) => {
-    const slug = deriveArtifactSlug(artifact.slug)
+    const { slug, pagePath } = deriveArtifactPaths(artifact.slug)
     // D-05: hash the distributed-payload bytes only (single-file = body).
     const hash = sha256Hex(artifact.body)
     const prior = priorVersionManifest[slug]
@@ -266,6 +302,7 @@ export function versionAndValidateArtifacts(
       type: artifact.type,
       version,
       description: artifact.description,
+      pagePath,
       files: [
         {
           path: artifact.destination,
@@ -278,7 +315,7 @@ export function versionAndValidateArtifacts(
   })
 
   const multis: ValidatedArtifact[] = data.multiArtifacts.map((artifact) => {
-    const slug = deriveArtifactSlug(artifact.slug)
+    const { slug, pagePath } = deriveArtifactPaths(artifact.slug)
     // D-05: hash concatenated file.content in declared order (no separator —
     // boundaries are immaterial to the consumer-facing payload).
     const concatenated = artifact.files.map((f) => f.content).join('')
@@ -299,12 +336,38 @@ export function versionAndValidateArtifacts(
       type: artifact.type,
       version,
       description: artifact.description,
+      pagePath,
       files: artifact.files,
       devDependencies: artifact.devDependencies,
     }
   })
 
   const allArtifacts = [...singles, ...multis]
+
+  // Duplicate derived slugs and duplicate replace-merge destinations were
+  // silent last-write-wins — the Bug 012 class. Fail the build instead.
+  const slugSources = new Map<string, string>()
+  const replaceDestinations = new Map<string, string>()
+  for (const artifact of allArtifacts) {
+    const priorSlugSource = slugSources.get(artifact.slug)
+    if (priorSlugSource) {
+      throw new Error(
+        `Duplicate artifact slug '${artifact.slug}' derived from both '${priorSlugSource}' and '${artifact.pagePath}'`,
+      )
+    }
+    slugSources.set(artifact.slug, artifact.pagePath)
+
+    for (const file of artifact.files) {
+      if (file.merge !== 'replace') continue
+      const priorDest = replaceDestinations.get(file.path)
+      if (priorDest) {
+        throw new Error(
+          `Duplicate replace-merge destination '${file.path}' declared by both '${priorDest}' and '${artifact.slug}' — the second silently clobbers the first on apply`,
+        )
+      }
+      replaceDestinations.set(file.path, artifact.slug)
+    }
+  }
 
   for (const artifact of allArtifacts) {
     if (!SlugSchema.safeParse(artifact.slug).success) {
@@ -341,10 +404,14 @@ export function versionAndValidateArtifacts(
 
 // --- 6. Static registry JSON files for CLI/HTTP consumption ---
 
-export function writeRegistryFiles(allArtifacts: ValidatedArtifact[]): void {
+export function writeRegistryFiles(
+  allArtifacts: ValidatedArtifact[],
+  registryDirOverride?: string,
+): void {
   const baseUrl =
     process.env.NEXT_PUBLIC_SITE_URL || 'https://blakepetersen.io'
-  const registryDir = path.resolve(process.cwd(), 'public', 'r')
+  const registryDir =
+    registryDirOverride ?? path.resolve(process.cwd(), 'public', 'r')
 
   // Clean stale files
   fs.rmSync(registryDir, { recursive: true, force: true })
@@ -356,7 +423,8 @@ export function writeRegistryFiles(allArtifacts: ValidatedArtifact[]): void {
     type: artifact.type,
     version: artifact.version,
     description: artifact.description,
-    url: `${baseUrl}/${artifact.type}s/${artifact.slug}`,
+    // pagePath is the real site route — `<type>s/<slug>` 404'd for nested entries
+    url: `${baseUrl}/${artifact.pagePath}`,
   }))
 
   // Use max CalVer version as generatedAt (avoids noisy git diffs from wall-clock time)
@@ -385,9 +453,11 @@ export function writeRegistryFiles(allArtifacts: ValidatedArtifact[]): void {
     const typeDir = path.join(registryDir, artifact.type)
     fs.mkdirSync(typeDir, { recursive: true })
 
+    // pagePath is site-internal; the published detail carries the resolved url
+    const { pagePath, ...publishable } = artifact
     const detail = {
-      ...artifact,
-      url: `${baseUrl}/${artifact.type}s/${artifact.slug}`,
+      ...publishable,
+      url: `${baseUrl}/${pagePath}`,
     }
 
     fs.writeFileSync(

--- a/apps/blakepetersen.io/tests/registry-pipeline.test.ts
+++ b/apps/blakepetersen.io/tests/registry-pipeline.test.ts
@@ -1,0 +1,220 @@
+// ABOUTME: Tests for registry pipeline correctness — nested-artifact URLs, duplicate
+// ABOUTME: guards, manifest corruption handling, and posts cross-ref validation.
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createHash } from 'node:crypto'
+import {
+  versionAndValidateArtifacts,
+  writeRegistryFiles,
+  validateCrossReferences,
+  type DxData,
+} from '../src/lib/velite-prepare'
+
+function sha256Hex(payload: string): string {
+  return createHash('sha256').update(payload).digest('hex')
+}
+
+function makeContentDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'registry-pipeline-test-'))
+}
+
+function emptyData(overrides: Partial<DxData> = {}): DxData {
+  return {
+    skills: [],
+    hooks: [],
+    configs: [],
+    guides: [],
+    posts: [],
+    singleArtifacts: [],
+    multiArtifacts: [],
+    ...overrides,
+  }
+}
+
+function seedVersions(
+  contentDir: string,
+  entries: Array<{ slug: string; content: string; version: string }>
+): void {
+  const manifest = Object.fromEntries(
+    entries.map((e) => [e.slug, { hash: sha256Hex(e.content), version: e.version }])
+  )
+  fs.writeFileSync(
+    path.join(contentDir, '.artifact-versions.json'),
+    JSON.stringify(manifest)
+  )
+}
+
+function makeSingle(velitePath: string, body = 'body', destination = 'dest') {
+  return {
+    slug: velitePath,
+    name: 'x',
+    type: 'skill',
+    description: 'd',
+    destination,
+    body,
+    merge: 'replace' as const,
+  }
+}
+
+describe('nested artifact page paths (registry 404 fix)', () => {
+  it('derives slug from the basename but keeps the full page path', () => {
+    const contentDir = makeContentDir()
+    seedVersions(contentDir, [
+      { slug: 'writing-custom-skills', content: 'body', version: '2026.01.01.0' },
+    ])
+    const data = emptyData({
+      singleArtifacts: [makeSingle('skills/claude-code/writing-custom-skills.artifact')],
+    })
+
+    const [artifact] = versionAndValidateArtifacts(data, contentDir)
+    expect(artifact.slug).toBe('writing-custom-skills')
+    expect(artifact.pagePath).toBe('skills/claude-code/writing-custom-skills')
+  })
+
+  it('writes registry URLs from the page path, not the reconstructed type/slug', () => {
+    const contentDir = makeContentDir()
+    seedVersions(contentDir, [
+      { slug: 'writing-custom-skills', content: 'body', version: '2026.01.01.0' },
+    ])
+    const data = emptyData({
+      singleArtifacts: [makeSingle('skills/claude-code/writing-custom-skills.artifact')],
+    })
+    const artifacts = versionAndValidateArtifacts(data, contentDir)
+
+    const registryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-out-'))
+    writeRegistryFiles(artifacts, registryDir)
+
+    const index = JSON.parse(
+      fs.readFileSync(path.join(registryDir, 'index.json'), 'utf-8')
+    )
+    expect(index.items[0].url).toBe(
+      'https://blakepetersen.io/skills/claude-code/writing-custom-skills'
+    )
+
+    const detail = JSON.parse(
+      fs.readFileSync(
+        path.join(registryDir, 'skill', 'writing-custom-skills.json'),
+        'utf-8'
+      )
+    )
+    expect(detail.url).toBe(
+      'https://blakepetersen.io/skills/claude-code/writing-custom-skills'
+    )
+    // pagePath is site-internal — not part of the published registry contract
+    expect(detail.pagePath).toBeUndefined()
+  })
+})
+
+describe('duplicate guards (Bug 012 class)', () => {
+  it('throws when two artifacts derive the same slug', () => {
+    const contentDir = makeContentDir()
+    seedVersions(contentDir, [{ slug: 'foo', content: 'body', version: '2026.01.01.0' }])
+    const data = emptyData({
+      singleArtifacts: [
+        makeSingle('skills/foo.artifact', 'body', 'dest-a'),
+        makeSingle('skills/claude-code/foo.artifact', 'body', 'dest-b'),
+      ],
+    })
+
+    expect(() => versionAndValidateArtifacts(data, contentDir)).toThrow(
+      /[Dd]uplicate artifact slug/
+    )
+  })
+
+  it('throws when two artifacts declare the same replace-merge destination', () => {
+    const contentDir = makeContentDir()
+    seedVersions(contentDir, [
+      { slug: 'foo', content: 'body', version: '2026.01.01.0' },
+      { slug: 'bar', content: 'body', version: '2026.01.01.1' },
+    ])
+    const data = emptyData({
+      singleArtifacts: [
+        makeSingle('skills/foo.artifact', 'body', '.husky/pre-push'),
+        makeSingle('skills/bar.artifact', 'body', '.husky/pre-push'),
+      ],
+    })
+
+    expect(() => versionAndValidateArtifacts(data, contentDir)).toThrow(
+      /[Dd]uplicate.*destination/
+    )
+  })
+
+  it('allows two artifacts to share a section-merge destination', () => {
+    const contentDir = makeContentDir()
+    seedVersions(contentDir, [
+      { slug: 'foo', content: 'body', version: '2026.01.01.0' },
+      { slug: 'bar', content: 'body', version: '2026.01.01.1' },
+    ])
+    const data = emptyData({
+      singleArtifacts: [
+        { ...makeSingle('skills/foo.artifact', 'body', '.zshrc'), merge: 'section' as const },
+        { ...makeSingle('skills/bar.artifact', 'body', '.zshrc'), merge: 'section' as const },
+      ],
+    })
+
+    expect(() => versionAndValidateArtifacts(data, contentDir)).not.toThrow()
+  })
+})
+
+describe('version manifest corruption', () => {
+  it('reports the manifest path and recovery step on unparseable JSON', () => {
+    const contentDir = makeContentDir()
+    fs.writeFileSync(
+      path.join(contentDir, '.artifact-versions.json'),
+      '{ "broken": '
+    )
+    const data = emptyData({
+      singleArtifacts: [makeSingle('skills/foo.artifact')],
+    })
+
+    expect(() => versionAndValidateArtifacts(data, contentDir)).toThrow(
+      /\.artifact-versions\.json.*delete/
+    )
+  })
+})
+
+describe('posts cross-reference validation', () => {
+  it('fails the build when a post declares a dangling related ref', () => {
+    const data = emptyData({
+      skills: [
+        {
+          slug: 'skills/real-skill',
+          title: 'Real',
+          category: 'c',
+          dependencies: [],
+          related: [],
+        },
+      ],
+      posts: [
+        {
+          slug: 'posts/my-post',
+          related: ['skills/does-not-exist'],
+        },
+      ],
+    })
+
+    expect(() => validateCrossReferences(data)).toThrow(/does-not-exist/)
+  })
+
+  it('accepts post refs to existing DX entries and other posts', () => {
+    const data = emptyData({
+      skills: [
+        {
+          slug: 'skills/real-skill',
+          title: 'Real',
+          category: 'c',
+          dependencies: [],
+          related: [],
+        },
+      ],
+      posts: [
+        { slug: 'posts/first', related: ['skills/real-skill', 'posts/second'] },
+        { slug: 'posts/second', related: [] },
+      ],
+    })
+
+    expect(() => validateCrossReferences(data)).not.toThrow()
+  })
+})

--- a/apps/blakepetersen.io/tests/velite-prepare-cross-refs.test.ts
+++ b/apps/blakepetersen.io/tests/velite-prepare-cross-refs.test.ts
@@ -84,7 +84,7 @@ describe('validateCrossReferences', () => {
         makeDxItem({ slug: 'skills/b', title: 'B', related: ['guides/missing-3'] }),
       ],
     })
-    expect(() => validateCrossReferences(data)).toThrow(/Broken cross-references in DX content \(3\)/)
+    expect(() => validateCrossReferences(data)).toThrow(/Broken cross-references in content \(3\)/)
   })
 
   it('handles nested-slug refs against path-shaped slugs', () => {


### PR DESCRIPTION
## Summary

Fifth audit workstream — the artifact/registry pipeline's live defect plus its unguarded recurrence vectors:

- **Live 404s fixed**: registry URLs were rebuilt as `<type>s/<basename-slug>`, wrong for every nested entry (verified live: `writing-custom-skills` published `/skills/writing-custom-skills`, page lives at `/skills/claude-code/writing-custom-skills`). `ValidatedArtifact` now carries the full `pagePath`; URLs build from it.
- **Bug-012-class guards**: duplicate derived slugs and duplicate replace-merge destinations were silent last-write-wins — both now fail the build naming the colliding sources (section-merge sharing stays legal).
- **posts.related validated**: previously bypassed build-time cross-ref validation and silently dropped at render; now flows through the same D-04 accumulator (targets: DX collections + posts). Accumulator error carries a stable `BlinkCrossRefError` name (999.2).
- **Manifest corruption is actionable**: `.artifact-versions.json` parse failures report the path + delete-to-regenerate recovery instead of a bare SyntaxError inside Velite's prepare hook (999.2).
- **git-history**: one subprocess per file instead of two + shell pipe (velite build ~6.5s → ~5.0s), `execFileSync` arg-array instead of shell interpolation, and the shallow-clone fallback that silently fabricated "New (today)" freshness now warns.

Backlog mapping: closes the JSON.parse and error-tagging items from 999.2 and part of 999.1; the remaining 999.1 typing work (Sha256Hex/CalVer primitives, schema single-source-of-truth) is WS-7, filed in the backlog.

## Verification

- [x] TDD: 8 new tests (nested URL derivation + registry output, duplicate guards, corruption message, posts refs) red→green
- [x] bp.io suite 42 suites / 290 tests green; typecheck clean; lint 0 errors
- [x] Live velite build: nested entry now publishes the correct URL; `pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)