### PR TITLE
fix(cli): write-safety & global scope (WS-6)

### DIFF
--- a/packages/blink-cli/src/commands/apply.ts
+++ b/packages/blink-cli/src/commands/apply.ts
@@ -92,17 +92,23 @@ export default defineCommand({
       }
     }
 
-    // 6. Write files
-    const fileEntries: ManifestFileEntry[] = []
-
-    for (const plan of filePlans) {
-      if (plan.markerConflict) {
+    // 6. Write files — conflicts are known up-front, so check them all before
+    // writing anything. The old mid-loop check wrote earlier files, then
+    // returned exit 0, leaving an untracked partial install in the repo.
+    const conflicts = filePlans.filter((plan) => plan.markerConflict)
+    if (conflicts.length > 0) {
+      for (const plan of conflicts) {
         consola.error(
           `${pc.bold(slug)} is already installed in ${plan.path}. Use ${pc.dim('blink update')} to update.`,
         )
-        return
       }
+      process.exitCode = 1
+      return
+    }
 
+    const fileEntries: ManifestFileEntry[] = []
+
+    for (const plan of filePlans) {
       if (plan.exists && plan.merge === 'replace') {
         if (dryRun) {
           consola.log(

--- a/packages/blink-cli/src/commands/diff.ts
+++ b/packages/blink-cli/src/commands/diff.ts
@@ -7,7 +7,7 @@ import { readFile } from 'node:fs/promises'
 import { fetchArtifact } from '@/registry'
 import { readManifest } from '@/manifest'
 import { findManagedSections } from '@/markers'
-import { resolveDestination } from '@/scope'
+import { resolveDestination, resolveManifestRoot } from '@/scope'
 import { formatColoredDiff } from '@/output'
 
 async function readFileSafe(path: string): Promise<string | null> {
@@ -29,13 +29,19 @@ export default defineCommand({
       description: 'Artifact slug to diff',
       required: true,
     },
+    global: {
+      type: 'boolean',
+      description: 'Operate on the global (home-directory) manifest',
+      default: false,
+    },
   },
   async run({ args }) {
     const slug = args.slug as string
     const cwd = process.cwd()
 
     // 1. Read manifest
-    const manifest = await readManifest(cwd)
+    const manifestRoot = resolveManifestRoot(args.global ? 'global' : 'project', cwd)
+    const manifest = await readManifest(manifestRoot)
 
     if (!manifest) {
       consola.error('No blink manifest found. Run blink init first.')

--- a/packages/blink-cli/src/commands/doctor.ts
+++ b/packages/blink-cli/src/commands/doctor.ts
@@ -8,7 +8,7 @@ import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { readManifest, checksum } from '@/manifest'
 import { validateMarkers, findManagedSections } from '@/markers'
-import { resolveDestination } from '@/scope'
+import { resolveDestination, resolveManifestRoot } from '@/scope'
 
 interface DoctorIssue {
   severity: 'error' | 'warning' | 'info'
@@ -51,13 +51,20 @@ export default defineCommand({
     name: 'doctor',
     description: 'Check integrity of blink-managed files and manifest',
   },
-  args: {},
+  args: {
+    global: {
+      type: 'boolean',
+      description: 'Operate on the global (home-directory) manifest',
+      default: false,
+    },
+  },
   async run({ args }) {
     const cwd = process.cwd()
     const issues: DoctorIssue[] = []
 
     // 1. Read manifest
-    const manifest = await readManifest(cwd)
+    const manifestRoot = resolveManifestRoot(args.global ? 'global' : 'project', cwd)
+    const manifest = await readManifest(manifestRoot)
 
     if (!manifest) {
       consola.info(

--- a/packages/blink-cli/src/commands/eject.ts
+++ b/packages/blink-cli/src/commands/eject.ts
@@ -43,14 +43,20 @@ export default defineCommand({
       description: 'Skip confirmation prompts',
       default: false,
     },
+    global: {
+      type: 'boolean',
+      description: 'Operate on the global (home-directory) manifest',
+      default: false,
+    },
   },
   async run({ args }) {
     const slug = args.slug as string
     const dryRun = args['dry-run']
     const cwd = process.cwd()
 
-    // 1. Read manifest
-    const manifest = await readManifest(cwd)
+    // 1. Read manifest — written back to the same root it was read from
+    const manifestRoot = resolveManifestRoot(args.global ? 'global' : 'project', cwd)
+    const manifest = await readManifest(manifestRoot)
 
     if (!manifest) {
       consola.error('No blink manifest found. Run blink init or blink apply first.')
@@ -64,8 +70,6 @@ export default defineCommand({
       consola.error(`${pc.bold(slug)} is not installed.`)
       process.exit(1)
     }
-
-    const manifestRoot = resolveManifestRoot(entry.scope, cwd)
 
     // 3. Process each file
     for (const file of entry.files) {

--- a/packages/blink-cli/src/commands/status.ts
+++ b/packages/blink-cli/src/commands/status.ts
@@ -5,6 +5,7 @@ import { consola } from 'consola'
 import { readManifest } from '@/manifest'
 import { fetchIndex } from '@/registry'
 import { formatStatusTable } from '@/output'
+import { resolveManifestRoot } from '@/scope'
 
 export default defineCommand({
   meta: {
@@ -17,9 +18,18 @@ export default defineCommand({
       description: 'Output raw JSON',
       default: false,
     },
+    global: {
+      type: 'boolean',
+      description: 'Operate on the global (home-directory) manifest',
+      default: false,
+    },
   },
   async run({ args }) {
-    const manifest = await readManifest(process.cwd())
+    const manifestRoot = resolveManifestRoot(
+      args.global ? 'global' : 'project',
+      process.cwd(),
+    )
+    const manifest = await readManifest(manifestRoot)
 
     if (!manifest) {
       consola.warn('blink is not initialized. Run `blink init` first.')

--- a/packages/blink-cli/src/commands/update.ts
+++ b/packages/blink-cli/src/commands/update.ts
@@ -41,6 +41,11 @@ export default defineCommand({
       description: 'Skip confirmation prompts',
       default: false,
     },
+    global: {
+      type: 'boolean',
+      description: 'Operate on the global (home-directory) manifest',
+      default: false,
+    },
   },
   async run({ args }) {
     const slug = args.slug as string | undefined
@@ -49,7 +54,8 @@ export default defineCommand({
     const cwd = process.cwd()
 
     // 1. Read manifest
-    const manifest = await readManifest(cwd)
+    const manifestRoot = resolveManifestRoot(args.global ? 'global' : 'project', cwd)
+    const manifest = await readManifest(manifestRoot)
 
     if (!manifest) {
       consola.error('No blink manifest found. Run blink init first.')
@@ -74,7 +80,9 @@ export default defineCommand({
 
     for (const entry of items) {
       const artifact = await fetchArtifact(entry.type, entry.slug)
-      const manifestRoot = resolveManifestRoot(entry.scope, cwd)
+      // The manifest is written back to the root it was read from — the old
+      // per-entry resolveManifestRoot(entry.scope, …) could write a project
+      // manifest into the home directory (and vice versa).
       const newFileEntries: ManifestFileEntry[] = []
       let hasChanges = false
 

--- a/packages/blink-cli/src/manifest.ts
+++ b/packages/blink-cli/src/manifest.ts
@@ -1,9 +1,10 @@
 // ABOUTME: Manifest manager for tracking installed blink artifacts.
 // ABOUTME: Handles reading, writing, and creating .blink/manifest.json files.
-import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 import { ManifestSchema, type Manifest, type ManifestEntry } from 'blink-registry'
+import { atomicWrite } from '@/writer'
 
 export const BLINK_DIR = '.blink'
 const MANIFEST_FILE = 'manifest.json'
@@ -40,10 +41,10 @@ export async function writeManifest(
   cwd: string,
   manifest: Manifest
 ): Promise<void> {
-  const dir = join(cwd, BLINK_DIR)
-  await mkdir(dir, { recursive: true })
-  await writeFile(
-    join(dir, MANIFEST_FILE),
+  // Atomic (temp + rename): a crash mid-write must not leave a truncated
+  // manifest, which readers surface as MANIFEST_CORRUPT with no recovery.
+  await atomicWrite(
+    join(cwd, BLINK_DIR, MANIFEST_FILE),
     JSON.stringify(manifest, null, 2) + '\n'
   )
 }

--- a/packages/blink-cli/src/registry.ts
+++ b/packages/blink-cli/src/registry.ts
@@ -25,12 +25,24 @@ async function fetchWithRetry(url: string): Promise<Response> {
       })
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status} ${response.statusText}`)
+        const error = new Error(
+          `HTTP ${response.status} ${response.statusText} for ${url}`,
+        )
+        // 4xx is deterministic — retrying a 404/403 just burns the backoff
+        // budget and delays the real error by several seconds.
+        if (response.status >= 400 && response.status < 500) {
+          throw Object.assign(error, { permanent: true })
+        }
+        throw error
       }
 
       return response
     } catch (error) {
       lastError = error as Error
+
+      if ((error as { permanent?: boolean }).permanent) {
+        throw error
+      }
 
       if (attempt < MAX_RETRIES - 1) {
         const delay = Math.min(1000 * 2 ** attempt, 5000)

--- a/packages/blink-cli/tests/commands/apply.test.ts
+++ b/packages/blink-cli/tests/commands/apply.test.ts
@@ -619,4 +619,45 @@ describe('blink apply', () => {
       expect(existsSync(join(tmpDir, '.eslintrc.json'))).toBe(true)
     })
   })
+
+  describe('marker-conflict pre-flight', () => {
+    it('writes nothing and exits non-zero when any file has a marker conflict', async () => {
+      // Two files: the second collides with an existing managed section.
+      // The old mid-loop check wrote the first file, then returned exit 0,
+      // leaving an untracked partial install.
+      const twoFileArtifact = {
+        slug: 'shellrc',
+        name: 'Shell RC',
+        type: 'config' as const,
+        version: '2026.03.14.1',
+        description: 'Shell RC managed section',
+        url: 'https://blakepetersen.io/r/config/shellrc',
+        files: [
+          { path: 'fresh-file.txt', content: 'new content', merge: 'replace' as const },
+          { path: '.zshrc', content: 'export FOO=1', merge: 'section' as const },
+        ],
+        devDependencies: undefined,
+      }
+      // Existing managed section for the same slug in .zshrc → conflict
+      writeFileSync(
+        join(tmpDir, '.zshrc'),
+        '# blink:start shellrc\nold\n# blink:end shellrc\n',
+      )
+
+      const originalExitCode = process.exitCode
+      fetchMock = jest.fn()
+        .mockResolvedValueOnce({ ok: true, json: async () => MOCK_INDEX_EXTENDED })
+        .mockResolvedValueOnce({ ok: true, json: async () => twoFileArtifact })
+      global.fetch = fetchMock
+
+      await runApply({ slug: 'shellrc', yes: true })
+
+      expect(existsSync(join(tmpDir, 'fresh-file.txt'))).toBe(false)
+      expect(consolaMock.error).toHaveBeenCalledWith(
+        expect.stringContaining('already installed'),
+      )
+      expect(process.exitCode).toBe(1)
+      process.exitCode = originalExitCode
+    })
+  })
 })

--- a/packages/blink-cli/tests/commands/status.test.ts
+++ b/packages/blink-cli/tests/commands/status.test.ts
@@ -37,6 +37,12 @@ const validIndex: RegistryIndex = {
   generatedAt: '2026-03-15T00:00:00.000Z',
 }
 
+let mockHomedir: string
+jest.mock('node:os', () => ({
+  ...jest.requireActual('node:os'),
+  homedir: () => mockHomedir,
+}))
+
 jest.mock('citty', () => ({
   defineCommand: (config: any) => config,
 }))
@@ -82,6 +88,7 @@ let mockConsoleLog: jest.SpyInstance
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'blink-status-'))
+  mockHomedir = mkdtempSync(join(tmpdir(), 'blink-status-home-'))
   originalCwd = process.cwd()
   process.chdir(tmpDir)
   mockFetchIndex.mockReset()
@@ -116,6 +123,24 @@ async function runStatus(args: Record<string, boolean> = {}) {
   const command = mod.default
   await command.run!({ args: { json: false, ...args } } as any)
 }
+
+describe('blink status --global', () => {
+  it('reads the global manifest from the home directory', async () => {
+    // Global installs were write-only: apply --global recorded to the homedir
+    // manifest, but every reader hardcoded process.cwd().
+    const globalEntry = { ...sampleEntry, slug: 'global-skill', name: 'Global Skill', scope: 'global' as const }
+    mkdirSync(join(mockHomedir, BLINK_DIR), { recursive: true })
+    writeFileSync(
+      join(mockHomedir, BLINK_DIR, 'manifest.json'),
+      JSON.stringify({ version: 1, items: [globalEntry] }, null, 2),
+    )
+
+    await runStatus({ json: true, global: true })
+
+    const logged = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n')
+    expect(logged).toContain('global-skill')
+  })
+})
 
 describe('blink status', () => {
   it('shows warning when no manifest exists', async () => {

--- a/packages/blink-cli/tests/manifest-atomic.test.ts
+++ b/packages/blink-cli/tests/manifest-atomic.test.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Verifies writeManifest goes through the atomic writer.
+// ABOUTME: A plain writeFile can leave a truncated manifest (MANIFEST_CORRUPT) on crash.
+
+const atomicWriteMock = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('@/writer', () => ({
+  atomicWrite: (...args: unknown[]) => atomicWriteMock(...args),
+}))
+
+import { writeManifest, createEmptyManifest, BLINK_DIR } from '@/manifest'
+import { join } from 'node:path'
+
+describe('writeManifest atomicity', () => {
+  it('writes the manifest through atomicWrite (temp-file + rename)', async () => {
+    await writeManifest('/tmp/some-project', createEmptyManifest())
+
+    expect(atomicWriteMock).toHaveBeenCalledTimes(1)
+    const [destPath, content] = atomicWriteMock.mock.calls[0]
+    expect(destPath).toBe(join('/tmp/some-project', BLINK_DIR, 'manifest.json'))
+    expect(() => JSON.parse(content as string)).not.toThrow()
+  })
+})

--- a/packages/blink-cli/tests/registry.test.ts
+++ b/packages/blink-cli/tests/registry.test.ts
@@ -126,6 +126,24 @@ describe('fetchIndex', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(result).toEqual(validIndex)
   })
+
+  it('does not retry 4xx responses — a 404 will not heal on backoff', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+    globalThis.fetch = mockFetch
+
+    await expect(fetchIndex()).rejects.toThrow(/404/)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes the failing URL in HTTP error messages', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+
+    await expect(fetchIndex()).rejects.toThrow(/r\/index\.json/)
+  })
 })
 
 describe('fetchArtifact', () => {


### PR DESCRIPTION
## Summary

Sixth audit workstream — the CLI's core contract (safe, tracked writes into user repos) had three verified holes:

- **`--global` installs were write-only**: `apply --global` recorded to the home-directory manifest, but update/status/diff/eject/doctor all hardcoded `process.cwd()` — a global artifact could never be listed, updated, diffed, ejected, or health-checked again. All five readers now take `--global` and resolve through `scope.ts`. Also fixes the cross-scope write-back in update/eject that could write a project manifest into the home directory.
- **Marker conflicts abandoned partial installs**: the mid-write-loop conflict check errored after earlier files were already written, then returned exit 0 — untracked files in the user's repo and a green exit. Conflicts (known up-front from file plans) are now checked before any write; apply exits 1.
- **Manifest writes weren't atomic**: `writeManifest` used bare `writeFile`, violating the package's own stated invariant — a crash mid-write left a truncated manifest surfacing as `MANIFEST_CORRUPT` with no recovery. Now routed through the existing `atomicWrite`.
- Bonus: registry `fetchWithRetry` no longer retries 4xx (deterministic; burned ~3s of backoff before surfacing the same 404), and HTTP errors now name the failing URL.

## Verification

- [x] TDD: new tests for all four fixes (status `--global` via homedir mock, apply conflict pre-flight, manifest atomicity, retry policy) red→green
- [x] blink-cli 27 suites / 267 tests green; typecheck clean
- [x] Full repo `pnpm build && pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)