### PR TITLE
fix(ci): un-break main — blink bin never linked in CI

### DIFF
--- a/apps/blakepetersen.io/package.json
+++ b/apps/blakepetersen.io/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf .next && rm -rf .turbo && rm -rf node_modules",
     "dev": "next dev --webpack",
     "lint": "eslint .",
-    "lint:content": "blink lint --content-root content",
+    "lint:content": "node ../../packages/blink-cli/dist/cli.mjs lint --content-root content",
     "migrate": "tsx scripts/migrate-content.ts",
     "perf:baseline": "tsx scripts/perf-baseline.ts",
     "start": "next start",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -27,11 +27,11 @@ export default {
   // Staged-only content lint (LINT-05). The runner dispatches by collection,
   // so posts and .artifact.md siblings passed here are filtered, not
   // mis-validated against the DX schema (the old "phantom errors").
-  // The CLI bin resolves to packages/blink-cli/dist/, which doesn't exist on
-  // a fresh clone — build it first (tsup, sub-second when warm) so the hook
-  // fails on real lint errors rather than a missing binary.
+  // Invoked by node path, not the `blink` bin: pnpm only links workspace bins
+  // whose dist/ exists at install time, so the bin is absent in CI and fresh
+  // clones (install runs before build). Build first — tsup, sub-second warm.
   'apps/blakepetersen.io/content/**/*.{mdx,md}': (files) => [
     'pnpm --filter @blink/cli build',
-    `pnpm --filter blakepetersen.io exec blink lint --files ${files.join(',')}`,
+    `node packages/blink-cli/dist/cli.mjs lint --files ${files.join(',')}`,
   ],
 }


### PR DESCRIPTION
## Summary

**Main has been red since #131 merged** — `pnpm lint:content` fails on every main push with `sh: 1: blink: not found`.

Root cause: pnpm links a workspace package's bin only if its `dist/` exists at install time. CI runs `pnpm install` before `pnpm build`, so the `blink` bin symlink is never created in CI (or any fresh clone). The #131 PR run had the same latent issue; its `ci` check hadn't completed when it was merged — that's a process failure on my end (truncated check-watch output), now corrected: full check verification before every merge.

Fix: invoke the CLI by node path (`node ../../packages/blink-cli/dist/cli.mjs`) in `lint:content` and the lint-staged hook. Turbo's `lint:content → ^build` dependency guarantees the file exists.

## Verification

- [x] Exact CI order in a fresh worktree: `pnpm install --frozen-lockfile && pnpm build && pnpm lint:content` → exit 0
- [x] lint-staged path from repo root with `--files` → `✔ No issues found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)