### PR TITLE
refactor: schema single-source-of-truth — blink-registry ↔ Velite (Phase 31)

### DIFF
--- a/apps/blakepetersen.io/scripts/migrate-content.ts
+++ b/apps/blakepetersen.io/scripts/migrate-content.ts
@@ -4,12 +4,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-
-interface Migration {
-  name: string
-  description: string
-  run(contentRoot: string): Promise<{ filesChanged: number }>
-}
+import type { Migration } from './migrations/types'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/apps/blakepetersen.io/scripts/migrations/000-noop.ts
+++ b/apps/blakepetersen.io/scripts/migrations/000-noop.ts
@@ -1,9 +1,7 @@
 // ABOUTME: Phase 27 SCHEMA-06 stub migration — no-op placeholder validating harness wiring.
 // ABOUTME: Real migrations replace this pattern: read contentRoot, transform files, return count.
 
-interface MigrationResult {
-  filesChanged: number
-}
+import type { MigrationResult } from './types'
 
 export default {
   name: '000-noop',

--- a/apps/blakepetersen.io/scripts/migrations/types.ts
+++ b/apps/blakepetersen.io/scripts/migrations/types.ts
@@ -1,0 +1,11 @@
+// ABOUTME: Shared migration-harness contract — the one declaration of Migration + MigrationResult.
+// ABOUTME: run() signature intentionally unchanged (run(opts) deferred until Migration #001 lands).
+export interface MigrationResult {
+  filesChanged: number
+}
+
+export interface Migration {
+  name: string
+  description: string
+  run(contentRoot: string): Promise<MigrationResult>
+}

--- a/apps/blakepetersen.io/src/lib/velite-fields.ts
+++ b/apps/blakepetersen.io/src/lib/velite-fields.ts
@@ -1,0 +1,32 @@
+// ABOUTME: Side-effect-free Velite dxFields map, rebuilt from blink-registry's canonical
+// ABOUTME: const arrays/regex so velite.config.ts and the schema-parity test share one source.
+import { s } from 'velite'
+import { DX_COLLECTIONS, VOICE_PRIMITIVES, crossRefRegex } from 'blink-registry'
+
+// Cross-references in `dependencies` and `related` must be of shape
+// `<dx-collection>/<slug-path>`. Catches typos like 'skill/foo' (singular) or
+// 'foo' (no collection prefix) at frontmatter-parse time, before the cross-ref
+// validator's existence check runs in the prepare hook.
+export const CrossRefSchema = s
+  .string()
+  .regex(
+    crossRefRegex(DX_COLLECTIONS),
+    `must be '<collection>/<slug-path>' where collection is one of: ${DX_COLLECTIONS.join(', ')}`,
+  )
+
+// Shared fields for DX content types (skills, hooks, configs, guides)
+export const dxFields = {
+  title: s.string().max(120),
+  description: s.string().max(260),
+  applies_to: s.array(s.string()),
+  dependencies: s.array(CrossRefSchema).default([]),
+  order: s.number().optional(),
+  draft: s.boolean().default(false),
+  tags: s.array(s.string()).default([]),
+  voice: s.array(s.enum([...VOICE_PRIMITIVES])).default([]),
+  requires_artifact: s.boolean().default(false),
+  category: s.string().optional(),
+  decisions: s.array(s.object({ choice: s.string(), rationale: s.string() })).default([]),
+  related: s.array(CrossRefSchema).default([]),
+  updated_context: s.isodate().optional(),
+}

--- a/apps/blakepetersen.io/src/lib/velite-prepare.ts
+++ b/apps/blakepetersen.io/src/lib/velite-prepare.ts
@@ -18,6 +18,9 @@ import {
   CalVerSchema,
   ArtifactTypeSchema,
   MergeStrategySchema,
+  type Slug,
+  type CalVer,
+  type Sha256Hex,
 } from 'blink-registry'
 
 // --- Types ---
@@ -239,7 +242,7 @@ export function extractGitHistory(
 
 // --- 5. Artifact versioning + Zod validation (SCHEMA-08 / D-05..D-07) ---
 
-type VersionManifest = Record<string, { hash: string; version: string }>
+type VersionManifest = Record<Slug, { hash: Sha256Hex; version: CalVer }>
 
 function deriveArtifactPaths(velitePath: string): { slug: string; pagePath: string } {
   const pagePath = velitePath

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-bad-updated-context/content/skills/bad-date.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-bad-updated-context/content/skills/bad-date.mdx
@@ -1,0 +1,7 @@
+---
+title: Bad Date Skill
+description: updated_context is not an ISO date — must be rejected
+applies_to: ["test"]
+updated_context: "last week"
+---
+Bad updated_context body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-bad-updated-context/velite.fixture.config.ts
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-bad-updated-context/velite.fixture.config.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Phase 31 fixture velite config — malformed updated_context (should-fail) scenario.
+// ABOUTME: Reuses the base config schemas; roots at this fixture's content/ tree.
+
+import { defineConfig } from 'velite'
+import baseConfig from '../../../velite.config'
+
+export default defineConfig({
+  ...baseConfig,
+  root: './content',
+  output: {
+    ...baseConfig.output,
+    data: '.velite-fixture',
+    clean: true,
+  },
+})

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-singular-cross-ref/content/skills/singular.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-singular-cross-ref/content/skills/singular.mdx
@@ -1,0 +1,8 @@
+---
+title: Singular Cross Ref Skill
+description: dependency uses a singular collection prefix — must be rejected
+applies_to: ["test"]
+dependencies:
+  - "skill/foo"
+---
+Singular cross-ref body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-singular-cross-ref/velite.fixture.config.ts
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-singular-cross-ref/velite.fixture.config.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Phase 31 fixture velite config — singular cross-ref prefix (should-fail) scenario.
+// ABOUTME: Reuses the base config schemas; roots at this fixture's content/ tree.
+
+import { defineConfig } from 'velite'
+import baseConfig from '../../../velite.config'
+
+export default defineConfig({
+  ...baseConfig,
+  root: './content',
+  output: {
+    ...baseConfig.output,
+    data: '.velite-fixture',
+    clean: true,
+  },
+})

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-unknown-voice/content/skills/bogus-voice.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-unknown-voice/content/skills/bogus-voice.mdx
@@ -1,0 +1,8 @@
+---
+title: Bogus Voice Skill
+description: voice uses an unknown primitive — must be rejected
+applies_to: ["test"]
+voice:
+  - "bogus"
+---
+Bogus voice body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-unknown-voice/velite.fixture.config.ts
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-unknown-voice/velite.fixture.config.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Phase 31 fixture velite config — unknown voice primitive (should-fail) scenario.
+// ABOUTME: Reuses the base config schemas; roots at this fixture's content/ tree.
+
+import { defineConfig } from 'velite'
+import baseConfig from '../../../velite.config'
+
+export default defineConfig({
+  ...baseConfig,
+  root: './content',
+  output: {
+    ...baseConfig.output,
+    data: '.velite-fixture',
+    clean: true,
+  },
+})

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/baseline.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/baseline.mdx
@@ -1,0 +1,6 @@
+---
+title: Baseline Skill
+description: Valid baseline frontmatter exercised through both schemas
+applies_to: ["test"]
+---
+Baseline body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/cross-ref.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/cross-ref.mdx
@@ -1,0 +1,8 @@
+---
+title: Cross Ref Source
+description: References an existing skill via a valid collection-prefixed slug
+applies_to: ["test"]
+dependencies:
+  - "skills/target"
+---
+Cross-ref source body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/iso-updated-context.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/iso-updated-context.mdx
@@ -1,0 +1,7 @@
+---
+title: ISO Updated Context Skill
+description: Valid ISO date in updated_context (the tightened field)
+applies_to: ["test"]
+updated_context: "2026-07-01"
+---
+ISO updated_context body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/target.mdx
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/content/skills/target.mdx
@@ -1,0 +1,6 @@
+---
+title: Cross Ref Target
+description: Existence proof for the cross-ref source entry
+applies_to: ["test"]
+---
+Cross-ref target body.

--- a/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/velite.fixture.config.ts
+++ b/apps/blakepetersen.io/test-fixtures/phase31/schema-parity-valid/velite.fixture.config.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Phase 31 fixture velite config — schema-parity valid (should-pass) scenario.
+// ABOUTME: Reuses the base config schemas; roots at this fixture's content/ tree.
+
+import { defineConfig } from 'velite'
+import baseConfig from '../../../velite.config'
+
+export default defineConfig({
+  ...baseConfig,
+  root: './content',
+  output: {
+    ...baseConfig.output,
+    data: '.velite-fixture',
+    clean: true,
+  },
+})

--- a/apps/blakepetersen.io/tests/schema-parity.test.ts
+++ b/apps/blakepetersen.io/tests/schema-parity.test.ts
@@ -1,0 +1,75 @@
+// ABOUTME: SSOT-08 round-trip parity guarding the registry(Zod v4)↔Velite(Zod v3) schema seam.
+// ABOUTME: Same fixtures run through registry safeParse and a real Velite build; catches updated_context drift.
+import path from 'node:path'
+import { DxFrontmatterSchema } from 'blink-registry'
+import { runVeliteFixture } from './lib/phase27-velite-runner'
+
+// Velite 0.3.x is ESM-only (type: module, sole ./dist/index.js export, no CJS
+// build) and cannot be imported into the app's CJS ts-jest runtime. The Velite
+// half of the parity check is therefore driven through a real `velite build`
+// subprocess (the Phase 27 velite-runner) against fixture content validated by
+// the SAME dxFields schema (velite.config.ts -> src/lib/velite-fields.ts). A
+// build also exercises Velite's isodate throw-on-invalid-date as a clean
+// non-zero exit, which an in-process safeParse would surface as a raw throw.
+const parityFixture = (scenario: string) =>
+  path.resolve(__dirname, '..', 'test-fixtures', 'phase31', scenario)
+
+const base = {
+  title: 'Parity Fixture',
+  description: 'A frontmatter fixture exercised through both schemas',
+  applies_to: ['claude-code'],
+}
+
+// [name, frontmatter, both-schemas-should-accept]. The Velite fixtures under
+// test-fixtures/phase31/ carry the same frontmatter values.
+const registryFixtures: [name: string, input: Record<string, unknown>, shouldPass: boolean][] = [
+  ['valid baseline', { ...base }, true],
+  ['valid updated_context', { ...base, updated_context: '2026-07-01' }, true],
+  ['malformed updated_context', { ...base, updated_context: 'last week' }, false],
+  ['singular cross-ref prefix', { ...base, dependencies: ['skill/foo'] }, false],
+  ['valid cross-ref', { ...base, dependencies: ['skills/foo-bar'] }, true],
+  ['unknown voice value', { ...base, voice: ['bogus'] }, false],
+]
+
+describe('registry ↔ Velite schema parity (SSOT-08)', () => {
+  // Registry half (Zod v4): field-level validation on the in-memory fixtures.
+  describe('registry DxFrontmatterSchema (Zod v4)', () => {
+    test.each(registryFixtures)('%s → accepts=%s', (_name, input, shouldPass) => {
+      expect(DxFrontmatterSchema.safeParse(input).success).toBe(shouldPass)
+    })
+  })
+
+  // Velite half (Zod v3): the same frontmatter driven through a real Velite
+  // build. Should-pass cases are batched into one build; each should-fail case
+  // is its own build so the failing field is isolated.
+  describe('Velite build (Zod v3), same fixtures', () => {
+    it('accepts baseline + ISO updated_context + resolvable cross-ref in one build', () => {
+      const result = runVeliteFixture(parityFixture('schema-parity-valid'))
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('rejects malformed updated_context "last week" (the drift SSOT-08 guards)', () => {
+      const result = runVeliteFixture(parityFixture('schema-parity-bad-updated-context'))
+      expect(result.exitCode).not.toBe(0)
+      // Velite's s.isodate() rejects the non-ISO value; the registry's z.iso.date()
+      // rejects the same string (registry half above) — the seam agrees.
+      expect(result.combined.toLowerCase()).toMatch(/invalid time value|invalid date/)
+    })
+
+    it('rejects singular cross-ref prefix "skill/foo"', () => {
+      const result = runVeliteFixture(parityFixture('schema-parity-singular-cross-ref'))
+      expect(result.exitCode).not.toBe(0)
+      // CrossRefSchema is rebuilt from crossRefRegex(DX_COLLECTIONS).
+      expect(result.combined).toContain("must be '<collection>/<slug-path>'")
+      expect(result.combined).toContain('dependencies')
+    })
+
+    it('rejects unknown voice value "bogus"', () => {
+      const result = runVeliteFixture(parityFixture('schema-parity-unknown-voice'))
+      expect(result.exitCode).not.toBe(0)
+      // voice enum is rebuilt from VOICE_PRIMITIVES.
+      expect(result.combined.toLowerCase()).toMatch(/voice/)
+      expect(result.combined).toContain('bogus')
+    })
+  })
+})

--- a/apps/blakepetersen.io/tsconfig.json
+++ b/apps/blakepetersen.io/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "../../packages/tsconfig/nextjs.json",
   "compilerOptions": {
+    // This app never emits declaration files (noEmit); `declaration` is inherited
+    // from the shared base preset. Leaving it on makes tsc enforce declaration-emit
+    // nameability (TS4023) on exported values whose inferred types reference Velite's
+    // bundled-but-unexported Zod internals (ParseContext, RefinementCtx, ...) — which
+    // blocks sharing `dxFields` from velite-fields.ts. Off here; packages still emit.
+    "declaration": false,
+    "declarationMap": false,
     "paths": {
       "@/*": ["./src/*"],
       "#content": ["./.velite"]

--- a/apps/blakepetersen.io/velite.config.ts
+++ b/apps/blakepetersen.io/velite.config.ts
@@ -159,8 +159,7 @@ const multiArtifacts = defineCollection({
     }),
 })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const config: any = defineConfig({
+const config = defineConfig({
   root: 'content',
   output: {
     data: '.velite',

--- a/apps/blakepetersen.io/velite.config.ts
+++ b/apps/blakepetersen.io/velite.config.ts
@@ -17,37 +17,8 @@ import {
   writeRegistryFiles,
   type DxData,
 } from './src/lib/velite-prepare'
-
-// DX collection names — single source of truth for cross-ref prefix validation.
-const DX_COLLECTIONS = ['skills', 'hooks', 'configs', 'guides'] as const
-
-// Cross-references in `dependencies` and `related` must be of shape
-// `<dx-collection>/<slug-path>`. Catches typos like 'skill/foo' (singular) or
-// 'foo' (no collection prefix) at frontmatter-parse time, before the cross-ref
-// validator's existence check runs in the prepare hook.
-const CrossRefSchema = s
-  .string()
-  .regex(
-    new RegExp(`^(${DX_COLLECTIONS.join('|')})/[a-z0-9-]+(/[a-z0-9-]+)*$`),
-    `must be '<collection>/<slug-path>' where collection is one of: ${DX_COLLECTIONS.join(', ')}`,
-  )
-
-// Shared fields for DX content types (skills, hooks, configs, guides)
-const dxFields = {
-  title: s.string().max(120),
-  description: s.string().max(260),
-  applies_to: s.array(s.string()),
-  dependencies: s.array(CrossRefSchema).default([]),
-  order: s.number().optional(),
-  draft: s.boolean().default(false),
-  tags: s.array(s.string()).default([]),
-  voice: s.array(s.enum(['author-note', 'decision-rationale'])).default([]),
-  requires_artifact: s.boolean().default(false),
-  category: s.string().optional(),
-  decisions: s.array(s.object({ choice: s.string(), rationale: s.string() })).default([]),
-  related: s.array(CrossRefSchema).default([]),
-  updated_context: s.isodate().optional(),
-}
+import { ARTIFACT_TYPES, MERGE_STRATEGIES } from 'blink-registry'
+import { dxFields } from './src/lib/velite-fields'
 
 /**
  * Per-collection bare-slug uniqueness helper for SCHEMA-03.
@@ -151,8 +122,8 @@ const singleArtifacts = defineCollection({
   schema: s.object({
     name: s.string(),
     description: s.string(),
-    type: s.enum(['config', 'skill', 'hook', 'guide']),
-    merge: s.enum(['replace', 'section']),
+    type: s.enum([...ARTIFACT_TYPES]),
+    merge: s.enum([...MERGE_STRATEGIES]),
     destination: s.string(),
     devDependencies: s.record(s.string(), s.string()).optional().default({}),
     slug: s.path(),
@@ -167,12 +138,12 @@ const multiArtifacts = defineCollection({
     .object({
       name: s.string(),
       description: s.string(),
-      type: s.enum(['config', 'skill', 'hook', 'guide']),
+      type: s.enum([...ARTIFACT_TYPES]),
       devDependencies: s.record(s.string(), s.string()).optional().default({}),
       files: s.array(
         s.object({
           path: s.string(),
-          merge: s.enum(['replace', 'section']),
+          merge: s.enum([...MERGE_STRATEGIES]),
         }),
       ),
       slug: s.path(),

--- a/packages/blink-cli/package.json
+++ b/packages/blink-cli/package.json
@@ -16,8 +16,6 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
     "citty": "^0.2.2",
     "consola": "^3.4.2",
     "diff": "^8.0.4",

--- a/packages/blink-cli/src/lint/rules/frontmatter-schema.ts
+++ b/packages/blink-cli/src/lint/rules/frontmatter-schema.ts
@@ -1,69 +1,29 @@
-// ABOUTME: LINT-01 — validates MDX frontmatter against JSON Schema derived from DxFrontmatterSchema.
-// ABOUTME: Uses Ajv 8 with z.toJSONSchema() output. Severity: error (blocks CI per D-06).
-
-import Ajv, { type ValidateFunction } from 'ajv'
-import addFormats from 'ajv-formats'
-import { getDxJsonSchema } from 'blink-registry'
+// ABOUTME: LINT-01 — validates MDX frontmatter against DxFrontmatterSchema (Zod v4) directly.
+// ABOUTME: Supersedes the Ajv + z.toJSONSchema path (Blake 2026-07-12). Severity: error (blocks CI).
+import { DxFrontmatterSchema } from 'blink-registry'
 import type { LintDiagnostic, LintRule, LintContext } from '@/lint/types'
-
-const ajv = new Ajv({ allErrors: true, strict: false, validateSchema: false, useDefaults: true })
-addFormats(ajv)
-
-const fixAjv = new Ajv({ allErrors: true, strict: false, useDefaults: true, validateSchema: false })
-addFormats(fixAjv)
-
-let cachedValidate: ValidateFunction | null = null
-let cachedFixValidate: ValidateFunction | null = null
-
-function getSchema(): object {
-  const schema = getDxJsonSchema() as Record<string, unknown>
-  // Remove $schema field — Ajv 8 core doesn't support draft-2020-12 meta-schema
-  // but all validation keywords used (type, properties, required, default, pattern) are compatible
-  const { $schema, ...rest } = schema
-  return rest
-}
-
-function getValidator(): ValidateFunction {
-  if (!cachedValidate) {
-    cachedValidate = ajv.compile(getSchema())
-  }
-  return cachedValidate
-}
-
-function getFixValidator(): ValidateFunction {
-  if (!cachedFixValidate) {
-    cachedFixValidate = fixAjv.compile(getSchema())
-  }
-  return cachedFixValidate
-}
 
 export const frontmatterSchemaRule: LintRule = {
   name: 'frontmatter-schema',
 
   check(ctx: LintContext): LintDiagnostic[] {
-    const validate = getValidator()
-    const data = structuredClone(ctx.frontmatter)
-    const valid = validate(data)
+    const result = DxFrontmatterSchema.safeParse(ctx.frontmatter)
+    if (result.success) return []
 
-    if (valid) return []
-
-    return (validate.errors ?? []).map((err) => ({
+    return result.error.issues.map((issue) => ({
       file: ctx.file,
       severity: 'error' as const,
       rule: 'frontmatter-schema',
-      message: `${err.instancePath || '/'}: ${err.message}`,
+      message: `${issue.path.length ? '/' + issue.path.join('/') : '/'}: ${issue.message}`,
     }))
   },
 
   fix(ctx: LintContext): { frontmatter?: Record<string, unknown>; body?: string } | null {
-    const validate = getFixValidator()
-    const normalized = structuredClone(ctx.frontmatter)
-    validate(normalized)
+    const result = DxFrontmatterSchema.safeParse(ctx.frontmatter)
+    if (!result.success) return null // cannot apply defaults to structurally-invalid frontmatter
 
-    // Check if defaults were applied (object changed)
+    const normalized = result.data as Record<string, unknown>
     const changed = JSON.stringify(normalized) !== JSON.stringify(ctx.frontmatter)
-    if (!changed) return null
-
-    return { frontmatter: normalized as Record<string, unknown> }
+    return changed ? { frontmatter: normalized } : null
   },
 }

--- a/packages/blink-cli/src/pipeline.ts
+++ b/packages/blink-cli/src/pipeline.ts
@@ -17,11 +17,11 @@ import { injectMarkers, findManagedSections } from '@/markers'
 import { resolveDestination, resolveManifestRoot } from '@/scope'
 import { findMissingDeps } from '@/deps'
 import { addToGitignore } from '@/gitignore'
-import type { Manifest, ManifestEntry, ManifestFileEntry, MergeStrategy, RegistryArtifact } from 'blink-registry'
+import type { Manifest, ManifestEntry, ManifestFileEntry, MergeStrategy, RegistryArtifact, Scope } from 'blink-registry'
 
 // --- Pipeline types ---
 
-export type Scope = 'project' | 'global'
+export type { Scope } from 'blink-registry'
 
 export interface ResolveResult {
   artifact: RegistryArtifact

--- a/packages/blink-cli/src/scope.ts
+++ b/packages/blink-cli/src/scope.ts
@@ -2,10 +2,11 @@
 // ABOUTME: Maps file paths to project root or home directory based on scope flag.
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import type { Scope } from 'blink-registry'
 
 export function resolveDestination(
   filePath: string,
-  scope: 'project' | 'global',
+  scope: Scope,
   cwd: string
 ): string {
   if (scope === 'global') {
@@ -15,7 +16,7 @@ export function resolveDestination(
 }
 
 export function resolveManifestRoot(
-  scope: 'project' | 'global',
+  scope: Scope,
   cwd: string
 ): string {
   if (scope === 'global') {

--- a/packages/blink-cli/tests/lint/rules/frontmatter-schema.test.ts
+++ b/packages/blink-cli/tests/lint/rules/frontmatter-schema.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the frontmatter-schema lint rule (LINT-01).
-// ABOUTME: Validates MDX frontmatter against JSON Schema derived from DxFrontmatterSchema.
+// ABOUTME: Validates MDX frontmatter directly against DxFrontmatterSchema (Zod v4).
 import { frontmatterSchemaRule } from '@/lint/rules/frontmatter-schema'
 import type { LintContext } from '@/lint/types'
 
@@ -25,29 +25,29 @@ describe('frontmatterSchemaRule', () => {
     expect(diagnostics).toEqual([])
   })
 
-  it('returns error diagnostic for missing required field title', () => {
+  it('surfaces the offending field path for missing required field title', () => {
     const ctx = makeContext({
       description: 'Missing title.',
       applies_to: ['claude-code'],
     })
     const diagnostics = frontmatterSchemaRule.check(ctx)
     expect(diagnostics.length).toBeGreaterThan(0)
-    expect(diagnostics.some((d) => d.message.includes('title'))).toBe(true)
+    expect(diagnostics.some((d) => d.message.startsWith('/title:'))).toBe(true)
     expect(diagnostics[0].severity).toBe('error')
   })
 
-  it('returns error diagnostic for missing required field applies_to', () => {
+  it('surfaces the offending field path for missing required field applies_to', () => {
     const ctx = makeContext({
       title: 'Test',
       description: 'Missing applies_to.',
     })
     const diagnostics = frontmatterSchemaRule.check(ctx)
     expect(diagnostics.length).toBeGreaterThan(0)
-    expect(diagnostics.some((d) => d.message.includes('applies_to'))).toBe(true)
+    expect(diagnostics.some((d) => d.message.startsWith('/applies_to:'))).toBe(true)
     expect(diagnostics[0].severity).toBe('error')
   })
 
-  it('returns error diagnostic for wrong type (title as number)', () => {
+  it('reports a type mismatch under the field path (title as number)', () => {
     const ctx = makeContext({
       title: 42,
       description: 'Wrong type.',
@@ -55,11 +55,22 @@ describe('frontmatterSchemaRule', () => {
     })
     const diagnostics = frontmatterSchemaRule.check(ctx)
     expect(diagnostics.length).toBeGreaterThan(0)
-    expect(diagnostics.some((d) => d.message.includes('title') || d.message.includes('type'))).toBe(true)
+    const titleDiag = diagnostics.find((d) => d.message.startsWith('/title:'))
+    expect(titleDiag).toBeDefined()
+    expect(titleDiag!.message).toContain('expected string')
+  })
+
+  it('reports a non-ISO updated_context under its field path (registry tightened to z.iso.date)', () => {
+    const ctx = makeContext({
+      ...VALID_FRONTMATTER,
+      updated_context: 'last week',
+    })
+    const diagnostics = frontmatterSchemaRule.check(ctx)
+    expect(diagnostics.some((d) => d.message.startsWith('/updated_context:'))).toBe(true)
     expect(diagnostics[0].severity).toBe('error')
   })
 
-  it('applies defaults — omitted optional fields do not produce errors', () => {
+  it('omitted optional fields do not produce errors', () => {
     const ctx = makeContext({
       title: 'Minimal',
       description: 'Only required fields.',
@@ -69,7 +80,7 @@ describe('frontmatterSchemaRule', () => {
     expect(diagnostics).toEqual([])
   })
 
-  it('fix mode returns corrected frontmatter with defaults applied', () => {
+  it('fix mode returns normalized frontmatter with Zod defaults applied', () => {
     const ctx = makeContext({
       title: 'Fix Test',
       description: 'Needs defaults.',
@@ -78,10 +89,39 @@ describe('frontmatterSchemaRule', () => {
     const result = frontmatterSchemaRule.fix!(ctx)
     expect(result).not.toBeNull()
     expect(result!.frontmatter).toBeDefined()
+    expect(result!.frontmatter!.dependencies).toEqual([])
     expect(result!.frontmatter!.tags).toEqual([])
     expect(result!.frontmatter!.voice).toEqual([])
     expect(result!.frontmatter!.draft).toBe(false)
     expect(result!.frontmatter!.requires_artifact).toBe(false)
+    expect(result!.frontmatter!.decisions).toEqual([])
+    expect(result!.frontmatter!.related).toEqual([])
+  })
+
+  it('fix mode returns null for already-complete frontmatter (no change)', () => {
+    const ctx = makeContext({
+      title: 'Complete',
+      description: 'Nothing to default.',
+      applies_to: ['claude-code'],
+      dependencies: [],
+      draft: false,
+      tags: [],
+      voice: [],
+      requires_artifact: false,
+      decisions: [],
+      related: [],
+    })
+    const result = frontmatterSchemaRule.fix!(ctx)
+    expect(result).toBeNull()
+  })
+
+  it('fix mode returns null for structurally-invalid frontmatter (cannot default)', () => {
+    const ctx = makeContext({
+      description: 'Missing title.',
+      applies_to: ['claude-code'],
+    })
+    const result = frontmatterSchemaRule.fix!(ctx)
+    expect(result).toBeNull()
   })
 
   it('all diagnostics have severity error and rule name frontmatter-schema', () => {
@@ -91,6 +131,7 @@ describe('frontmatterSchemaRule', () => {
     for (const d of diagnostics) {
       expect(d.severity).toBe('error')
       expect(d.rule).toBe('frontmatter-schema')
+      expect(d.message.startsWith('/')).toBe(true)
     }
   })
 })

--- a/packages/blink-registry/src/index.ts
+++ b/packages/blink-registry/src/index.ts
@@ -53,5 +53,9 @@ export {
   DX_COLLECTIONS,
   DxFrontmatterSchema,
   getDxJsonSchema,
+  crossRefRegex,
+  VOICE_PRIMITIVES,
+  VoiceSchema,
   type DxFrontmatter,
+  type Voice,
 } from './schemas/dx-frontmatter.ts'

--- a/packages/blink-registry/src/index.ts
+++ b/packages/blink-registry/src/index.ts
@@ -2,15 +2,19 @@
 // ABOUTME: Single entry point for consuming packages to import from blink-registry.
 export {
   ArtifactTypeSchema,
+  ARTIFACT_TYPES,
   SlugSchema,
   CalVerSchema,
   MergeStrategySchema,
+  MERGE_STRATEGIES,
   ScopeSchema,
+  Sha256HexSchema,
   type ArtifactType,
   type Slug,
   type CalVer,
   type MergeStrategy,
   type Scope,
+  type Sha256Hex,
 } from './schemas/primitives.ts'
 
 export {

--- a/packages/blink-registry/src/schemas/dx-frontmatter.ts
+++ b/packages/blink-registry/src/schemas/dx-frontmatter.ts
@@ -9,14 +9,28 @@ import { z } from 'zod'
 export const DX_COLLECTIONS = ['skills', 'hooks', 'configs', 'guides'] as const
 
 /**
+ * Builds the anchored cross-reference regex for a set of collections.
+ * Shared with velite.config.ts (rebuilt via Velite's `s`) so both validators
+ * derive the SAME pattern from one source. Keep `^…$` / `[a-z0-9-]` intact —
+ * a path-traversal-shaped slug (`../`, `/`) cannot match.
+ */
+export function crossRefRegex(collections: readonly string[]): RegExp {
+  return new RegExp(`^(${collections.join('|')})/[a-z0-9-]+(/[a-z0-9-]+)*$`)
+}
+
+/**
  * Cross-reference format: `<collection>/<slug-path>`.
  * Mirrors the CrossRefSchema in velite.config.ts but uses project Zod (not Velite's `s`).
  */
-const CrossRefSchema = z
-  .string()
-  .regex(
-    new RegExp(`^(${DX_COLLECTIONS.join('|')})/[a-z0-9-]+(/[a-z0-9-]+)*$`),
-  )
+const CrossRefSchema = z.string().regex(crossRefRegex(DX_COLLECTIONS))
+
+/**
+ * Voice primitives — single source of truth shared with velite.config.ts.
+ * Order matters: velite rebuilds `s.enum([...VOICE_PRIMITIVES])`.
+ */
+export const VOICE_PRIMITIVES = ['author-note', 'decision-rationale'] as const
+export const VoiceSchema = z.enum(VOICE_PRIMITIVES)
+export type Voice = z.infer<typeof VoiceSchema>
 
 /**
  * Canonical schema for DX content frontmatter — mirrors the dxFields block
@@ -30,14 +44,14 @@ export const DxFrontmatterSchema = z.object({
   order: z.number().optional(),
   draft: z.boolean().default(false),
   tags: z.array(z.string()).default([]),
-  voice: z.array(z.enum(['author-note', 'decision-rationale'])).default([]),
+  voice: z.array(VoiceSchema).default([]),
   requires_artifact: z.boolean().default(false),
   category: z.string().optional(),
   decisions: z
     .array(z.object({ choice: z.string(), rationale: z.string() }))
     .default([]),
   related: z.array(CrossRefSchema).default([]),
-  updated_context: z.string().optional(),
+  updated_context: z.iso.date().optional(),
 })
 
 export type DxFrontmatter = z.infer<typeof DxFrontmatterSchema>

--- a/packages/blink-registry/src/schemas/primitives.ts
+++ b/packages/blink-registry/src/schemas/primitives.ts
@@ -2,18 +2,24 @@
 // ABOUTME: Defines artifact types, slug format, calendar versioning, merge strategies, and scopes.
 import { z } from 'zod'
 
-export const ArtifactTypeSchema = z.enum(['config', 'skill', 'hook', 'guide'])
+export const ARTIFACT_TYPES = ['config', 'skill', 'hook', 'guide'] as const
+export const MERGE_STRATEGIES = ['replace', 'section'] as const
+
+export const ArtifactTypeSchema = z.enum(ARTIFACT_TYPES)
 
 export const SlugSchema = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
 
 export const CalVerSchema = z.string().regex(/^\d{4}\.\d{2}\.\d{2}\.\d+$/)
 
-export const MergeStrategySchema = z.enum(['replace', 'section'])
+export const MergeStrategySchema = z.enum(MERGE_STRATEGIES)
 
 export const ScopeSchema = z.enum(['project', 'global'])
+
+export const Sha256HexSchema = z.string().regex(/^[a-f0-9]{64}$/)
 
 export type ArtifactType = z.infer<typeof ArtifactTypeSchema>
 export type Slug = z.infer<typeof SlugSchema>
 export type CalVer = z.infer<typeof CalVerSchema>
 export type MergeStrategy = z.infer<typeof MergeStrategySchema>
 export type Scope = z.infer<typeof ScopeSchema>
+export type Sha256Hex = z.infer<typeof Sha256HexSchema>

--- a/packages/blink-registry/tests/dx-frontmatter.test.ts
+++ b/packages/blink-registry/tests/dx-frontmatter.test.ts
@@ -4,6 +4,9 @@ import {
   DxFrontmatterSchema,
   getDxJsonSchema,
   DX_COLLECTIONS,
+  crossRefRegex,
+  VOICE_PRIMITIVES,
+  VoiceSchema,
 } from '../src/index'
 
 describe('DxFrontmatterSchema', () => {
@@ -46,6 +49,57 @@ describe('DxFrontmatterSchema', () => {
       voice: ['not-a-voice'],
     })
     expect(result.success).toBe(false)
+  })
+
+  it('accepts a valid voice primitive', () => {
+    const result = DxFrontmatterSchema.safeParse({
+      ...validSkillFrontmatter,
+      voice: ['author-note'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts an ISO date updated_context', () => {
+    const result = DxFrontmatterSchema.safeParse({
+      ...validSkillFrontmatter,
+      updated_context: '2026-07-01',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a non-ISO updated_context (closes the s.isodate drift)', () => {
+    const result = DxFrontmatterSchema.safeParse({
+      ...validSkillFrontmatter,
+      updated_context: 'last week',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('crossRefRegex', () => {
+  it('matches a well-formed cross-ref', () => {
+    expect(crossRefRegex(DX_COLLECTIONS).test('skills/foo')).toBe(true)
+  })
+
+  it('rejects an unknown collection', () => {
+    expect(crossRefRegex(DX_COLLECTIONS).test('skill/foo')).toBe(false)
+  })
+
+  it('rejects path-traversal-shaped slugs', () => {
+    expect(crossRefRegex(DX_COLLECTIONS).test('skills/../etc')).toBe(false)
+  })
+})
+
+describe('VOICE_PRIMITIVES', () => {
+  it("is exactly ['author-note', 'decision-rationale'] in that order", () => {
+    expect(VOICE_PRIMITIVES).toEqual(['author-note', 'decision-rationale'])
+  })
+
+  it('VoiceSchema accepts each primitive and rejects others', () => {
+    for (const v of VOICE_PRIMITIVES) {
+      expect(VoiceSchema.safeParse(v).success).toBe(true)
+    }
+    expect(VoiceSchema.safeParse('bogus').success).toBe(false)
   })
 })
 

--- a/packages/blink-registry/tests/primitives.test.ts
+++ b/packages/blink-registry/tests/primitives.test.ts
@@ -2,10 +2,13 @@
 // ABOUTME: Validates both acceptance of valid data and rejection of invalid data.
 import {
   ArtifactTypeSchema,
+  ARTIFACT_TYPES,
   SlugSchema,
   CalVerSchema,
   MergeStrategySchema,
+  MERGE_STRATEGIES,
   ScopeSchema,
+  Sha256HexSchema,
 } from '../src/index'
 
 describe('ArtifactTypeSchema', () => {
@@ -68,4 +71,33 @@ describe('ScopeSchema', () => {
   it.each(['local', 'user', ''])('rejects "%s"', (value) => {
     expect(ScopeSchema.safeParse(value).success).toBe(false)
   })
+})
+
+describe('ARTIFACT_TYPES', () => {
+  it("is exactly ['config', 'skill', 'hook', 'guide'] in that order", () => {
+    expect(ARTIFACT_TYPES).toEqual(['config', 'skill', 'hook', 'guide'])
+  })
+})
+
+describe('MERGE_STRATEGIES', () => {
+  it("is exactly ['replace', 'section'] in that order", () => {
+    expect(MERGE_STRATEGIES).toEqual(['replace', 'section'])
+  })
+})
+
+describe('Sha256HexSchema', () => {
+  it('accepts 64 lowercase hex characters', () => {
+    expect(Sha256HexSchema.safeParse('a'.repeat(64)).success).toBe(true)
+  })
+
+  it('rejects uppercase hex', () => {
+    expect(Sha256HexSchema.safeParse('A'.repeat(64)).success).toBe(false)
+  })
+
+  it.each(['abc', '', 'a'.repeat(63), 'a'.repeat(65), 'g'.repeat(64)])(
+    'rejects "%s"',
+    (value) => {
+      expect(Sha256HexSchema.safeParse(value).success).toBe(false)
+    }
+  )
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,12 +579,6 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
-      ajv:
-        specifier: ^8.20.0
-        version: 8.20.0
-      ajv-formats:
-        specifier: ^3.0.1
-        version: 3.0.1(ajv@8.20.0)
       citty:
         specifier: ^0.2.2
         version: 0.2.2
@@ -5588,14 +5582,6 @@ packages:
       ajv:
         optional: true
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: 8.18.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -5611,9 +5597,6 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -15922,10 +15905,6 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
       ajv: 6.14.0
@@ -15943,13 +15922,6 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0


### PR DESCRIPTION
## Summary
Phase 31 of the v1.4 milestone (promoted backlog 999.1, audit WS-7): every schema fact shared between blink-registry, the Velite config, and the CLI now has exactly one canonical export.

- **Registry canonical exports** (SSOT-01..04, 07): `ARTIFACT_TYPES`/`MERGE_STRATEGIES`/`VOICE_PRIMITIVES` const arrays, `crossRefRegex()` builder, `VoiceSchema`/`type Voice`, `Sha256Hex` primitive; `updated_context` tightened to `z.iso.date()` — closing the live drift where lint accepted what the build rejects
- **Velite consumes, never redefines** (SSOT-02..04): `dxFields` extracted to side-effect-free `src/lib/velite-fields.ts`, `s.enum`s rebuilt from the shared arrays; Zod-instance boundary respected (only inert data crosses)
- **Round-trip parity test** (SSOT-08): same fixtures through both validators via the Phase 27 velite-runner pattern — includes the `updated_context: 'last week'` reject-both case that would have caught the original drift
- **CLI imports canonical `Scope`** (SSOT-06); **Migration/MigrationResult lifted** to a shared types module, `run(opts)` deferred until Migration #001 exists (SSOT-09)
- **Type recovery** (SSOT-05, 07): `const config: any` removed with full `UserConfig<T>` inference; `VersionManifest` retyped `Record<Slug, { hash: Sha256Hex; version: CalVer }>` (compile-time only, JSON shape unchanged)
- **Dual-Ajv collapse** (Blake-approved 2026-07-12, supersedes LINT-01): `blink lint` frontmatter validation now goes through `DxFrontmatterSchema.safeParse` directly; `ajv` + `ajv-formats` dropped from blink-cli; lint tests assert the Zod issue format

## Verification
`pnpm build && pnpm typecheck && pnpm lint && pnpm lint:content && pnpm test` all green in the worktree (8/8 turbo test tasks, incl. the new 10-case parity suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)