### PR TITLE
docs: phase 31 close-out — supersession log, roadmap, phase 36 plans

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -45,7 +45,7 @@ Generators that produce schema-valid skeletons; templates derive from the canoni
 
 Cross-file invariants that ESLint can't enforce, exposed via a `blink` subcommand.
 
-- [x] **LINT-01**: `blink lint` subcommand validates frontmatter against the JSON Schema derived from Velite Zod (single source of truth)
+- [x] **LINT-01**: `blink lint` subcommand validates frontmatter via `DxFrontmatterSchema.safeParse` (single source of truth) — *original JSON-Schema/Ajv mechanism superseded by Phase 31 (31-06), Blake sign-off 2026-07-12*
 - [x] **LINT-02**: `blink lint` enforces artifact-pair sync — entries with `requires_artifact: true` must have a sibling `.artifact.md` (error); orphan `.artifact.md` files surface as warnings
 - [x] **LINT-03**: `blink lint` enforces voice-primitive invariants — entries that declare a `voice` value must invoke the matching JSX component in the body; entries with rationale-shaped headings flag as advisory if `voice: ['decision-rationale']` is missing
 - [x] **LINT-04
@@ -140,7 +140,7 @@ Which phases cover which requirements. Filled by the roadmapper.
 | SCAFFOLD-04 | Phase 28 | Complete |
 | SCAFFOLD-05 | Phase 28 | Complete |
 | SCAFFOLD-06 | Phase 28 | Complete |
-| LINT-01 | Phase 28 | Complete |
+| LINT-01 | Phase 28 (mechanism superseded in Phase 31) | Complete |
 | LINT-02 | Phase 28 | Complete |
 | LINT-03 | Phase 28 | Complete |
 | LINT-04 | Phase 28 | Complete |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -309,17 +309,20 @@ Plans:
 
 **Depends on**: Nothing (independent of the other v1.4 phases)
 
-**Requirements**: TBD
+**Requirements**: PARITY-01, PARITY-02, PARITY-03, DEDUP-01, DEDUP-02, TOKEN-01, DEP-01 *(derived from research must-haves — no formal REQ IDs mapped for this promoted-backlog phase)*
 
 - 15 of 19 components documented while the landing page claims 19 — contradiction pinned by two tests each asserting a different count; missing: modal, prev-next-nav, author-note, decision-rationale; add a barrel↔registry parity test
 - Byte-identical 87-line ThemeToggle duplicated in both apps — belongs in artax-ui per the repo's own design-system rule
 - Playground Prism theme hand-mirrors hex values from artax-ui `globals.css` with no token-sync test (the marker-parsing machinery already exists in `token-registry.ts`)
 - shamefully-hoist phantoms: artax-ui → `next/link` undeclared peer (`prev-next-nav.tsx`), artax → `prism-react-renderer` undeclared
 
-**Plans**: TBD
+**Plans**: 4 plans
 
 Plans:
-- [ ] TBD (run /gsd-plan-phase 36 to break down)
+- [ ] 36-01-PLAN.md — Document 4 missing components + shared barrel parser + set-based parity test (reconcile counts to 19)
+- [ ] 36-02-PLAN.md — Prism↔token sync test (curated 3 token-backed hexes, reuses token-registry parser)
+- [ ] 36-03-PLAN.md — Declare phantom deps (next peer in artax-ui, prism-react-renderer dep in artax)
+- [ ] 36-04-PLAN.md — Dedupe ThemeToggle into artax-ui + document as 20th showcase component (bump counts to 20)
 
 ## Progress
 
@@ -365,7 +368,7 @@ v1.4 phases execute in numeric order: 27 -> 28 -> 29 -> 30. Phase 28 has three i
 | 33. Code-Comment Citation Rot | v1.4 | 0/? | Not started | — |
 | 34. apps/luna Containment & Reintegration | v1.4 | 0/? | Not started | — |
 | 35. Dead & Unlinted Code Sweep | v1.4 | 0/? | Not started | — |
-| 36. Artax Showcase Parity & Design-System Hygiene | v1.4 | 0/? | Not started | — |
+| 36. Artax Showcase Parity & Design-System Hygiene | v1.4 | 0/4 | Not started | — |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -80,7 +80,7 @@ See: `.planning/milestones/v1.3-ROADMAP.md` for full details.
 - [x] **Phase 28: Authoring Scaffolds + Lint + Port** — `blink scaffold`, `blink lint` (advisory voice rules), `blink port` two-step pipeline, `<ArtifactBody>` include component
 - [x] **Phase 29: Content Authoring (Greenfield + Ports)** — 20 net-new entries shipped (5 skills, 7 configs, 4 hooks, 4 guides) — exceeded all CONTENT-01..04 floors; Variant 3 pattern locked; voice-primitive torture test green across desktop-light/dark + mobile
 - [ ] **Phase 30: Editorial Closure** — Real `/about` and `/start-here` copy, voice-primitive backfill across pre-existing MDX, Skills Detail typography polish, voice-lint promotion review, milestone audit
-- [ ] **Phase 31: Schema Single-Source-of-Truth** — Shared const arrays/regexes/unions between blink-registry, Velite, and CLI; fix `updated_context` drift; round-trip fixture test *(promoted from 999.1, audit WS-7)*
+- [x] **Phase 31: Schema Single-Source-of-Truth** — Shared const arrays/regexes/unions between blink-registry, Velite, and CLI; fix `updated_context` drift; round-trip fixture test *(promoted from 999.1, audit WS-7)*
 - [ ] **Phase 32: Test-Signal Integrity** — Fix tests that pass without proving what they claim: stale-cache passthrough, manifest byte-compare, visual suite in CI, CommandPalette a11y, turbo dependsOn *(promoted from 999.2, audit WS-8)*
 - [ ] **Phase 33: Code-Comment Citation Rot** — Rewrite `.planning/`-artifact-ID citations as self-contained WHYs; delete redundant step comments *(promoted from 999.3)*
 - [ ] **Phase 34: apps/luna Containment & Reintegration** — Luna vitest suite in CI (Postgres service container), vuln overrides refresh, toolchain drift, repo-wide prettier enforcement *(promoted from 999.4, audit WS-9)*
@@ -373,7 +373,7 @@ v1.4 phases execute in numeric order: 27 -> 28 -> 29 -> 30. Phase 28 has three i
 | 28. Authoring Scaffolds + Lint + Port | v1.4 | 6/6 | Complete    | 2026-05-05 |
 | 29. Content Authoring | v1.4 | 7/7 | Complete    | 2026-05-14 |
 | 30. Editorial Closure | v1.4 | 0/? | Not started | — |
-| 31. Schema Single-Source-of-Truth | v1.4 | 0/? | Not started | — |
+| 31. Schema Single-Source-of-Truth | v1.4 | 6/6 | Complete | 2026-07-13 |
 | 32. Test-Signal Integrity | v1.4 | 0/? | Not started | — |
 | 33. Code-Comment Citation Rot | v1.4 | 0/? | Not started | — |
 | 34. apps/luna Containment & Reintegration | v1.4 | 0/4 | Not started | — |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -199,7 +199,7 @@ Plans:
 
 **Depends on**: Phase 29 (schema and content landed; independent of Phase 30)
 
-**Requirements**: TBD
+**Requirements**: SSOT-01, SSOT-02, SSOT-03, SSOT-04, SSOT-05, SSOT-06, SSOT-07, SSOT-08, SSOT-09 (derived in 31-RESEARCH.md; no REQUIREMENTS.md mapping for this promoted backlog phase)
 
 Thirteen frontmatter fields, the cross-ref regex, collection lists, artifact-type/merge enums, the voice union, and the Scope type are each hand-mirrored across the registry, Velite config, and CLI — synced only by comments, with one live drift (`updated_context`: `s.isodate()` in Velite vs `z.string()` in the registry, so lint accepts what the build rejects). The Zod-instance constraint (decision 28-01) rules out sharing schema objects; share exported const arrays/regexes plus a round-trip fixture test instead.
 
@@ -213,10 +213,15 @@ Thirteen frontmatter fields, the cross-ref regex, collection lists, artifact-typ
 - Tighten `Migration` interface (`scripts/migrate-content.ts`) to `run(opts)` and lift `MigrationResult` to a shared module — gate on Migration #001
 - (Needs sign-off) collapse the dual-Ajv round-trip in `frontmatter-schema.ts` to `DxFrontmatterSchema.safeParse` — supersedes recorded LINT-01 decision
 
-**Plans**: TBD
+**Plans**: 6 plans
 
 Plans:
-- [ ] TBD (run /gsd-plan-phase 31 to break down)
+- [ ] 31-01-PLAN.md — Registry canonical exports: const arrays, crossRefRegex, VoiceSchema, Sha256Hex, updated_context fix (SSOT-01/02/03/04/07)
+- [ ] 31-02-PLAN.md — Velite dedup + side-effect-free velite-fields + round-trip parity test (SSOT-01/02/03/04/08)
+- [ ] 31-03-PLAN.md — CLI imports canonical Scope from registry (SSOT-06)
+- [ ] 31-04-PLAN.md — Shared Migration/MigrationResult type module; run(opts) deferred (SSOT-09, low-risk half)
+- [ ] 31-05-PLAN.md — VersionManifest retype + remove `const config: any` / DxData inference (SSOT-05/07)
+- [ ] 31-06-PLAN.md — FINAL (Blake-locked): collapse dual-Ajv to DxFrontmatterSchema.safeParse, drop ajv deps (supersedes LINT-01)
 
 ### Phase 32: Test-Signal Integrity
 
@@ -268,7 +273,7 @@ Plans:
 
 **Depends on**: Nothing (luna is isolated from the other v1.4 phases)
 
-**Requirements**: TBD
+**Requirements**: LUNA-CI-01, LUNA-VULN-01, LUNA-DRIFT-01, REPO-FMT-01, REPO-LINT-01 *(derived from research must-haves — no formal REQ IDs mapped for this promoted-backlog phase)*
 
 Luna is fully gate-exempt (`--filter=!Luna` everywhere, commit f5fcb07 "until proper integration work happens") with the exemption previously untracked — this entry is that tracking item.
 
@@ -280,10 +285,15 @@ Luna is fully gate-exempt (`--filter=!Luna` everywhere, commit f5fcb07 "until pr
 - Repo-wide prettier enforcement (CI `--check` + glob consistency) deferred from WS-3 — needs a whole-tree normalization commit first
 - Scoped eslint config for node-side build files (velite-prepare, git-history, scripts/) where `console` is the right tool — kills ~60 no-console warnings
 
-**Plans**: TBD
+**Two tracks** (per 34-RESEARCH.md): Track A = luna containment (CI job, vuln overrides, safe drift); Track B = repo-wide enforcement (prettier gate, scoped eslint). **Explicitly deferred** (breaking; documented with rationale in `34-DEFERRALS.md`): Tailwind 3→4, Stripe 19→22, @react-email/components replacement, TypeScript 5.5→6. **luna-tests CI job ships advisory** (not a required merge check) this phase; promotion is a documented human follow-up.
+
+**Plans**: 4 plans
 
 Plans:
-- [ ] TBD (run /gsd-plan-phase 34 to break down)
+- [ ] 34-01-PLAN.md — Wave 1 (Track A): luna vuln overrides refresh + turbo bump + safe toolchain drift (LUNA-VULN-01, LUNA-DRIFT-01)
+- [ ] 34-02-PLAN.md — Wave 1 (Track A): local green baseline + luna-tests CI job with postgres:16-alpine service (LUNA-CI-01)
+- [ ] 34-03-PLAN.md — Wave 2 (Track B): whole-tree prettier normalization + format:check CI gate + scoped no-console eslint (REPO-FMT-01, REPO-LINT-01)
+- [ ] 34-04-PLAN.md — Wave 3: deferral log + STATE update + phase-gate checkpoint (luna-tests green on PR)
 
 ### Phase 35: Dead & Unlinted Code Sweep
 
@@ -366,7 +376,7 @@ v1.4 phases execute in numeric order: 27 -> 28 -> 29 -> 30. Phase 28 has three i
 | 31. Schema Single-Source-of-Truth | v1.4 | 0/? | Not started | — |
 | 32. Test-Signal Integrity | v1.4 | 0/? | Not started | — |
 | 33. Code-Comment Citation Rot | v1.4 | 0/? | Not started | — |
-| 34. apps/luna Containment & Reintegration | v1.4 | 0/? | Not started | — |
+| 34. apps/luna Containment & Reintegration | v1.4 | 0/4 | Not started | — |
 | 35. Dead & Unlinted Code Sweep | v1.4 | 0/? | Not started | — |
 | 36. Artax Showcase Parity & Design-System Hygiene | v1.4 | 0/4 | Not started | — |
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Content Density
-status: planning
-stopped_at: Completed 29-07-PLAN.md — Phase 29 phase gate verified, all 5 ROADMAP success criteria evidenced, ready for /gsd-verify-work
-last_updated: "2026-07-07T23:08:48.093Z"
-last_activity: 2026-07-07
+status: "Phase 29 shipped (PR #121, docs PR #127). Betterment sweep landed 2026-07-08: WS-1 CI security rot (#128), WS-3 Velite dev loop (#129), WS-2 turbo graph (#130), WS-4 content lint gate (#131), WS-5 registry pipeline (#132), WS-6 blink-cli write-safety (#133). Remaining audit workstreams filed as backlog 999.x."
+stopped_at: "Betterment sweep complete (WS-1..6 merged, PRs #128–#133); remaining audit workstreams filed as backlog 999.x. Next: /gsd-plan-phase 30 (editorial closure — needs Blake-authored content)."
+last_updated: "2026-07-13T06:36:22.281Z"
+last_activity: 2026-07-08
 progress:
-  total_phases: 7
-  completed_phases: 3
-  total_plans: 29
-  completed_plans: 21
-  percent: 72
+  total_phases: 10
+  completed_phases: 4
+  total_plans: 43
+  completed_plans: 27
+  percent: 63
 ---
 
 # Project State
@@ -153,6 +153,7 @@ Progress: [████████░░] ~85% (Phase 30 remains for v1.4)
 - 29-07: Auto-verified human-verify checkpoint per Wave 3 less-hand-holding pacing — all 5 acceptance gates pass; bulk editorial review routed to /gsd-verify-work
 - 29-07: Did not re-run scripts/perf-baseline.ts (overwrites Phase 27 yardstick); hand-captured fullBuildWallMs/veliteWallMs/webpackCompileMs from gate runs; migrated build-perf-baseline.json schema flat→phased+delta (phase_27, phase_29, delta sub-objects); pattern reusable for v1.5+
 - 29-07: Variant 3 (architectural framing + quoted snippets + voice primitives + new-tab anchor to /install/[type]/[slug] for installable + NO inline ArtifactBody) locked as v1.4 canonical authoring pattern for all 4 DX collections; guides use MDX-only adaptation (no companion, no install anchor, requires_artifact:false) per D-14
+- **31-06:** Collapsed blink-cli `frontmatter-schema.ts` from the dual-Ajv round-trip (over `z.toJSONSchema()`) to `DxFrontmatterSchema.safeParse` — drops `ajv` + `ajv-formats`, removes the 28-02 `$schema`-stripping workaround. **Supersedes LINT-01 and decision 28-02.** Blake sign-off 2026-07-12. Error messages now use Zod issue paths (`/field: message`); `fix()` applies Zod defaults on successful parse only (no in-place mutation of invalid input). Lint tests in both `@blink/cli` and `blakepetersen.io` updated to the Zod format.
 
 ### v1.4 Roadmap Decisions (locked at planning time)
 
@@ -187,4 +188,4 @@ Last session: 2026-07-08
 Stopped at: Betterment sweep complete (WS-1..6 merged, PRs #128–#133); remaining audit workstreams filed as backlog 999.x. Next: /gsd-plan-phase 30 (editorial closure — needs Blake-authored content).
 Resume file: None
 
-**Planned Phase:** 29 (Content Authoring (Greenfield + Ports)) — 7 plans — 2026-05-10T07:19:23.134Z
+**Planned Phase:** 34 (apps/luna Containment & Reintegration) — 4 plans — 2026-07-13T06:36:22.277Z

--- a/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-01-PLAN.md
+++ b/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-01-PLAN.md
@@ -1,0 +1,240 @@
+---
+phase: 36-artax-showcase-parity-design-system-hygiene
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/artax/src/lib/component-counts.ts
+  - apps/artax/src/lib/component-registry.ts
+  - apps/artax/tests/component-registry.test.ts
+  - apps/artax/tests/component-counts.test.ts
+  - apps/artax/tests/barrel-registry-parity.test.ts
+autonomous: true
+requirements: [PARITY-01, PARITY-02, PARITY-03]
+
+must_haves:
+  truths:
+    - "The showcase registry documents all 19 barrel components — modal, prev-next-nav, author-note, decision-rationale are now navigable"
+    - "The sidebar links to all 19 components"
+    - "A barrel↔registry slug-set mismatch fails a test (drift fails CI)"
+    - "The landing-page 'Total' badge count equals the number of navigable component pages"
+  artifacts:
+    - path: "apps/artax/src/lib/component-registry.ts"
+      provides: "ComponentDef entries for modal, prev-next-nav, author-note, decision-rationale + sidebar links"
+      contains: "slug: 'modal'"
+    - path: "apps/artax/src/lib/component-counts.ts"
+      provides: "Shared getBarrelComponentSlugs() parser (one source of truth for barrel exports)"
+      exports: ["getBarrelComponentSlugs", "getComponentCounts"]
+    - path: "apps/artax/tests/barrel-registry-parity.test.ts"
+      provides: "Set-based parity guard: registry slugs === barrel folder names per tier"
+  key_links:
+    - from: "apps/artax/tests/barrel-registry-parity.test.ts"
+      to: "apps/artax/src/lib/component-counts.ts"
+      via: "import getBarrelComponentSlugs"
+      pattern: "getBarrelComponentSlugs"
+    - from: "apps/artax/src/lib/component-registry.ts"
+      to: "packages/artax-ui/src/index.ts"
+      via: "import { Modal, PrevNextNav, AuthorNote, DecisionRationale } from 'artax-ui'"
+      pattern: "from ['\"]artax-ui['\"]"
+---
+
+<objective>
+Close the showcase parity contradiction: the artax-ui barrel exports 19 components but the showcase documents only 15. Document the 4 missing components (modal, prev-next-nav, author-note, decision-rationale), extract a single shared barrel-parsing helper, and add a set-based parity test so any future drift between barrel and registry fails loudly.
+
+Purpose: The landing page advertises "19 Total" (derived from the barrel) while the sidebar can only navigate to 15 (derived from the registry). This plan makes the registry catch up to the barrel and pins the two together.
+Output: 4 new ComponentDef entries + sidebar links, a shared `getBarrelComponentSlugs()` parser, a new parity test, and reconciled count assertions (all reading 19).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-PATTERNS.md
+
+<interfaces>
+<!-- ComponentDef contract every new entry must satisfy. Source: apps/artax/src/lib/component-registry.ts:52-79 -->
+```typescript
+export interface PropDef { name: string; type: string; default: string; description: string }
+export interface CodeExample { label: string; code: string }
+export interface ComponentDef {
+  name: string
+  slug: string                         // MUST equal the artax-ui source FOLDER name (parity key)
+  tier: 'atoms' | 'molecules' | 'organisms'
+  description: string
+  imports: string                      // must match /from ['"]artax-ui['"]/
+  props: PropDef[]                     // length > 0 asserted
+  variants?: string[]
+  codeExamples: CodeExample[]          // must include { label: 'Basic' }; each code non-empty
+  a11y: string[]                       // length > 0 asserted
+  preview: (values?: Record<string, string>) => ReactNode   // returns non-null ReactNode
+  playground?: { enabled: boolean; defaultExampleIndex?: number }
+}
+```
+
+<!-- Barrel section markers are load-bearing. component-counts.ts slices on the literal
+     comments `// Atoms`, `// Molecules`, `// Organisms` in packages/artax-ui/src/index.ts.
+     The 4 missing components are already exported under those sections. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extract getBarrelComponentSlugs() helper and add the parity test (Wave 0)</name>
+  <files>apps/artax/src/lib/component-counts.ts, apps/artax/tests/barrel-registry-parity.test.ts</files>
+  <read_first>
+    - apps/artax/src/lib/component-counts.ts (the existing countUniqueSourcePaths regex + resolveIndexPath, lines 14-69)
+    - apps/artax/tests/component-counts.test.ts (analog test — top-level derive + describe/it)
+    - .planning/phases/36-artax-showcase-parity-design-system-hygiene/36-PATTERNS.md (section: component-counts.ts helper extraction + parity test sketch)
+  </read_first>
+  <action>
+    Refactor `apps/artax/src/lib/component-counts.ts` to expose ONE shared parser instead of a private regex (Open Q3 → extract, do NOT duplicate):
+
+    1. Add `export function getBarrelComponentSlugs(): Record<'atoms' | 'molecules' | 'organisms', Set<string>>`. Reuse the existing `resolveIndexPath()` resolver and the `// Atoms` / `// Molecules` / `// Organisms` section-slicing already present in `getComponentCounts()`. For each tier section, build a `Set<string>` of folder names via the existing pattern `new RegExp(\`from\\s+['"]\\./components/${tier}/([^/]+)/\`, 'g')`.
+    2. Rewrite `getComponentCounts()` to derive from the helper: `const s = getBarrelComponentSlugs(); return { atoms: s.atoms.size, molecules: s.molecules.size, organisms: s.organisms.size, total: s.atoms.size + s.molecules.size + s.organisms.size }`. This keeps ONE source of truth for "what the barrel exports."
+    3. Preserve the path-resolution triad in `resolveIndexPath()` verbatim (it survives both `pnpm --filter artax test` and root/turbo runs).
+
+    Create NEW file `apps/artax/tests/barrel-registry-parity.test.ts` (2-line `// ABOUTME:` header required, non-client so ABOUTME is lines 1-2):
+    ```typescript
+    import { getBarrelComponentSlugs } from '@/lib/component-counts'
+    import { getComponentsByTier } from '@/lib/component-registry'
+
+    for (const tier of ['atoms', 'molecules', 'organisms'] as const) {
+      it(`${tier}: registry slugs equal barrel folder names`, () => {
+        const registrySlugs = new Set(getComponentsByTier(tier).map((c) => c.slug))
+        expect(registrySlugs).toEqual(getBarrelComponentSlugs()[tier])
+      })
+    }
+    ```
+    Do NOT write a second regex here — reuse the shared helper only (this is the drift class the phase exists to kill).
+
+    NOTE: this parity test will be RED until Task 2 documents the 4 missing components (registry has 15, barrel has 19). That is expected — Task 2 turns it GREEN.
+  </action>
+  <acceptance_criteria>
+    - `rg -n "export function getBarrelComponentSlugs" apps/artax/src/lib/component-counts.ts` returns exactly one match
+    - `apps/artax/tests/barrel-registry-parity.test.ts` exists and its first line matches `^// ABOUTME:`
+    - `rg -c "new RegExp" apps/artax/tests/barrel-registry-parity.test.ts` returns 0 (no duplicated parser)
+    - `pnpm --filter artax test -- component-counts` passes (getComponentCounts refactor did not change the barrel-derived totals: atoms 6 / molecules 9 / organisms 4 / total 19)
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax test -- component-counts</automated>
+  </verify>
+  <done>getBarrelComponentSlugs() exported and consumed by getComponentCounts(); parity test file exists (RED, awaiting Task 2); component-counts test still green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add 4 ComponentDef entries (modal, prev-next-nav, author-note, decision-rationale) + sidebar links</name>
+  <files>apps/artax/src/lib/component-registry.ts</files>
+  <read_first>
+    - apps/artax/src/lib/component-registry.ts (Callout entry ~lines 575-639 as molecule template; Dialog entry ~lines 973-1072 as organism/preview template; import block lines 5-50; getSidebarSections lines 1183-1227; tier banners lines 421 and 880)
+    - packages/artax-ui/src/components/molecules/prev-next-nav/prev-next-nav.tsx (exact prop shape)
+    - packages/artax-ui/src/components/molecules/author-note/author-note.tsx (exact prop shape)
+    - packages/artax-ui/src/components/molecules/decision-rationale/decision-rationale.tsx (exact prop shape incl. Alternative type)
+    - packages/artax-ui/src/components/organisms/modal/modal.tsx (ModalProps: open?, onOpenChange?, size?: 'sm'|'md'|'lg', trigger?, children, className?; static members Modal.Title / Modal.Description / Modal.Close)
+  </read_first>
+  <action>
+    Extend `apps/artax/src/lib/component-registry.ts`. Previews use `const h = createElement` (line 82) — never react-live/JSX strings.
+
+    1. Add the 4 new symbols to the single `from 'artax-ui'` import: `Modal`, `PrevNextNav`, `AuthorNote`, `DecisionRationale` (plus any prop types the previews reference, e.g. `AuthorNoteProps`, `DecisionRationaleProps`, `Alternative`).
+
+    2. Add 3 molecule `ComponentDef` entries inside the `// ──── Molecules ──` section (after line 421 banner), mirroring the Callout entry's field ordering and density. For each: `slug` MUST equal the artax-ui source folder name (`prev-next-nav`, `author-note`, `decision-rationale`); `imports` matches `/from ['"]artax-ui['"]/`; `props` length > 0 (derive from the source .tsx); `codeExamples` includes a `{ label: 'Basic' }` entry with non-empty code; `a11y` length > 0; `preview` returns a non-null ReactNode via `h(...)`. OMIT the `variants` and `playground` keys (these are not cva-enum components and ship preview-only). Preview shapes per research:
+       - `prev-next-nav` (server-safe): `h(PrevNextNav, { prev: { href: '#', label: 'intro' }, next: { href: '#', label: 'setup' } })` — renders next/link internally, resolves in jest via hoisting (decision 26-01).
+       - `author-note` (server-safe): `h(AuthorNote, { author: ..., date: ... }, '<note body text>')` — match the source prop names.
+       - `decision-rationale` (server-safe): `h(DecisionRationale, { ...required props per DecisionRationaleProps/Alternative }, ...)`.
+
+    3. Add 1 organism `ComponentDef` entry for Modal inside the `// ──── Organisms ──` section (after line 880 banner), modeled on the Dialog preview (render closed, trigger + composition). `slug: 'modal'`, `tier: 'organisms'`. Preview mirrors Dialog but uses `Modal` + `Modal.Title`/`Modal.Description`/`Modal.Close` and passes `trigger` + `children` per `ModalProps` (render closed by default). OMIT `playground`.
+
+    4. Add matching sidebar entries in `getSidebarSections()`: three `{ name, href }` in the molecules block, one in the organisms block:
+       ```typescript
+       { name: 'PrevNextNav', href: '/components/molecules/prev-next-nav' },
+       { name: 'AuthorNote', href: '/components/molecules/author-note' },
+       { name: 'DecisionRationale', href: '/components/molecules/decision-rationale' },
+       { name: 'Modal', href: '/components/organisms/modal' },
+       ```
+
+    Do NOT add a `playground` key to any of the 4 — they must fall into the excluded bucket (Task 3 registers them in EXCLUDED_PLAYGROUND_SLUGS).
+  </action>
+  <acceptance_criteria>
+    - `rg -n "slug: '(modal|prev-next-nav|author-note|decision-rationale)'" apps/artax/src/lib/component-registry.ts` returns 4 matches
+    - `rg -c "playground" apps/artax/src/lib/component-registry.ts` count is unchanged from before this task (no playground key added to the 4)
+    - `pnpm --filter artax test -- barrel-registry-parity` passes (registry slug sets now equal barrel folder names for molecules and organisms)
+    - `pnpm typecheck` passes for artax (previews reference real exported symbols/types)
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax test -- barrel-registry-parity</automated>
+  </verify>
+  <done>All 4 missing components documented with valid ComponentDef entries + sidebar links; parity test GREEN; the 4 ship preview-only (no playground key).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Reconcile count assertions to 19 and register the 4 in the playground exclusion list</name>
+  <files>apps/artax/tests/component-registry.test.ts</files>
+  <read_first>
+    - apps/artax/tests/component-registry.test.ts (EXPECTED_MOLECULES/EXPECTED_ORGANISMS lines 12-15; length assertions lines 83, 87, 95, 99-101; playground partition ENABLED/EXCLUDED lines 205-246)
+    - .planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md (Pitfall 1 + Pitfall — playground partition)
+  </read_first>
+  <action>
+    Edit `apps/artax/tests/component-registry.test.ts` ONLY (component-counts.test.ts needs NO change — it already asserts the barrel's 6/9/4/19):
+
+    1. `EXPECTED_MOLECULES` (line ~14): add `'prev-next-nav'`, `'author-note'`, `'decision-rationale'`.
+    2. `EXPECTED_ORGANISMS` (line ~15): add `'modal'`.
+    3. `moleculesSection.items.length` (line ~83): `6` → `9`.
+    4. `organismsSection.items.length` (line ~87): `3` → `4`.
+    5. `getAllComponents()` total (line ~95): `toHaveLength(15)` → `toHaveLength(19)`.
+    6. `getComponentsByTier('molecules')` (line ~99): `6` → `9`; `getComponentsByTier('organisms')` (line ~101): `3` → `4`.
+    7. Playground partition (line ~218): add `'modal'`, `'prev-next-nav'`, `'author-note'`, `'decision-rationale'` to `EXCLUDED_PLAYGROUND_SLUGS`. The "no overlap, no gap" assertion (lines ~242-245) requires every registry slug to appear in exactly one of ENABLED/EXCLUDED — the 4 have no `playground` key so they belong in EXCLUDED.
+
+    Do NOT touch the ENABLED_PLAYGROUND_SLUGS list or component-counts.test.ts.
+  </action>
+  <acceptance_criteria>
+    - `rg -n "toHaveLength\(19\)" apps/artax/tests/component-registry.test.ts` returns at least one match; no remaining `toHaveLength(15)` for the total assertion
+    - `rg -n "'modal'|'prev-next-nav'|'author-note'|'decision-rationale'" apps/artax/tests/component-registry.test.ts` shows each in both EXPECTED_* arrays and EXCLUDED_PLAYGROUND_SLUGS
+    - `git diff --stat apps/artax/tests/component-counts.test.ts` shows no changes (this file is verify-only)
+    - `pnpm --filter artax test` passes fully (registry, counts, parity, playground partition all green)
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax test</automated>
+  </verify>
+  <done>All artax tests green at 19 documented components; playground partition covers the 4 preview-only entries; component-counts.test.ts untouched.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| build-time only | This plan adds documentation data + a parser + tests. No runtime input, no auth, no network, no user data crosses any boundary. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-36-01-01 | Tampering | showcase previews (createElement) | accept | Previews render static literals via `h(...)`; no react-live/JSX-string eval surface is introduced (the 4 new entries ship preview-only, no `playground` key). |
+| T-36-01-02 | Denial of Service | barrel↔registry drift | mitigate | The set-based parity test fails CI if the barrel and registry diverge — the invariant that motivated this phase is now machine-enforced. |
+</threat_model>
+
+<verification>
+- `pnpm --filter artax test` green (component-registry, component-counts, barrel-registry-parity, playground partition)
+- `pnpm typecheck` green for artax
+- Sidebar + landing badge now agree on 19 (manual: `pnpm --filter artax dev`, confirm 19 navigable component pages and the "19 Total" badge — routed to phase-end visual check per 36-VALIDATION.md Manual-Only)
+</verification>
+
+<success_criteria>
+- Registry documents all 19 barrel components; sidebar links to all 19
+- `getBarrelComponentSlugs()` is the single shared barrel parser (no duplicated regex)
+- Barrel↔registry drift fails `barrel-registry-parity.test.ts`
+- Landing "Total" count equals the navigable count (both 19)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-01-SUMMARY.md`
+</output>

--- a/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-02-PLAN.md
+++ b/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-02-PLAN.md
@@ -1,0 +1,138 @@
+---
+phase: 36-artax-showcase-parity-design-system-hygiene
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/artax/tests/playground-theme-token-sync.test.ts
+autonomous: true
+requirements: [TOKEN-01]
+
+must_haves:
+  truths:
+    - "The 3 token-backed Prism theme hex values are pinned to artax-ui dark-mode tokens by a test"
+    - "A shift in --background, --primary, or --muted-foreground fails CI instead of silently desyncing the editor theme"
+  artifacts:
+    - path: "apps/artax/tests/playground-theme-token-sync.test.ts"
+      provides: "Curated token-sync assertions for the 3 token-backed Prism hexes"
+  key_links:
+    - from: "apps/artax/tests/playground-theme-token-sync.test.ts"
+      to: "apps/artax/src/lib/token-registry.ts"
+      via: "import getTokensByCategory"
+      pattern: "getTokensByCategory"
+    - from: "apps/artax/tests/playground-theme-token-sync.test.ts"
+      to: "apps/artax/src/lib/playground-theme.ts"
+      via: "import artaxTerminalTheme (the Prism literals under test)"
+      pattern: "artaxTerminalTheme"
+---
+
+<objective>
+Replace the silent hand-mirroring of Prism theme hex values (in the artax playground) against artax-ui's design tokens with a machine-enforced token-sync test. The Prism theme mixes token-backed chrome colors with syntax-only palette colors; this test pins ONLY the 3 token-backed entries so a token shift fails loudly, while documenting why the 5 syntax colors are deliberately excluded.
+
+Purpose: `playground-theme.ts` currently carries a header comment saying "if tokens shift these literals must be swept by hand." That manual sweep is exactly the drift this hygiene phase eliminates — for the token-backed subset.
+Output: One new test file reusing the existing `token-registry.ts` CSS parser.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-PATTERNS.md
+
+<interfaces>
+<!-- Reuse this parser — do NOT write a new CSS parser (Don't-Hand-Roll). Source: token-registry.ts:228-257 -->
+```typescript
+export function getTokensByCategory(): TokenCategory[]
+// returns TokenValue[] with { cssVar, lightValue, darkValue, category }
+// darkValue is parsed from the [data-theme=dark] block of packages/artax-ui/src/styles/globals.css
+```
+<!-- Curated Prism→token mapping (Pitfall 2). Assert ONLY these 3 against darkValue, uppercase-normalized.
+     The other 5 Prism colors (#D4D4D4, #86EFAC, #9CA3AF, #93C5FD, #FBBF24) are syntax palette, NOT tokens. -->
+```typescript
+const PRISM_TO_TOKEN = {
+  '#0A0A0A': '--background',        // plain.backgroundColor
+  '#F59E0B': '--primary',          // keyword/operator, number/boolean
+  '#6B7280': '--muted-foreground', // comment
+} as const
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add the curated Prism↔token sync test (Wave 0)</name>
+  <files>apps/artax/tests/playground-theme-token-sync.test.ts</files>
+  <read_first>
+    - apps/artax/src/lib/token-registry.ts (getTokensByCategory lines 228-257; parseBlock lines 67-97; resolveGlobalsCssPath path triad)
+    - apps/artax/src/lib/playground-theme.ts (the artaxTerminalTheme: PrismTheme object, lines 12-27 — the hex literals under test)
+    - apps/artax/tests/token-reference.test.ts (analog test that already trusts getTokensByCategory)
+    - .planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md (Pitfall 2 — the full hex→token mapping table)
+  </read_first>
+  <behavior>
+    - Test 1: `--background` darkValue (uppercased) === `#0A0A0A` (Prism plain.backgroundColor)
+    - Test 2: `--primary` darkValue (uppercased) === `#F59E0B` (Prism keyword/operator + number/boolean)
+    - Test 3: `--muted-foreground` darkValue (uppercased) === `#6B7280` (Prism comment)
+    - Guard: a documented comment explains WHY the 5 syntax colors (#D4D4D4, #86EFAC, #9CA3AF, #93C5FD, #FBBF24) are excluded (syntax palette, not design tokens)
+  </behavior>
+  <action>
+    Create NEW file `apps/artax/tests/playground-theme-token-sync.test.ts` (2-line `// ABOUTME:` header, lines 1-2 — non-client file).
+
+    1. Import `getTokensByCategory` from `@/lib/token-registry` and `artaxTerminalTheme` from `@/lib/playground-theme`. Do NOT re-parse CSS — reuse `getTokensByCategory()` (Don't-Hand-Roll).
+    2. Build a flat lookup: `const byVar = new Map(getTokensByCategory().flatMap(c => c.tokens).map(t => [t.cssVar, t.darkValue]))`.
+    3. Encode the curated `PRISM_TO_TOKEN` table (the 3 entries from the interfaces block above) as an explicit const in the test.
+    4. For each `[prismHex, cssVar]` entry, assert `byVar.get(cssVar)!.toUpperCase() === prismHex` (uppercase-normalize both sides). Read the corresponding literals out of `artaxTerminalTheme` where practical so the test proves the Prism object actually uses those hexes (not just that the tokens exist) — cross-check at least `plain.backgroundColor` against `PRISM_TO_TOKEN['#0A0A0A']`.
+    5. Add a code comment above the table documenting the 5 excluded syntax colors and WHY (they are Prism syntax palette with no design-token equivalent — a naive "every hex is a token" assertion would fail on them).
+
+    Do NOT assert on any of the 5 syntax colors. Do NOT promote syntax colors to tokens (that is a design decision, out of scope for this hygiene phase — confirmed A3).
+  </action>
+  <acceptance_criteria>
+    - `apps/artax/tests/playground-theme-token-sync.test.ts` exists; first line matches `^// ABOUTME:`
+    - `rg -n "#0A0A0A|#F59E0B|#6B7280" apps/artax/tests/playground-theme-token-sync.test.ts` returns 3 hexes; `rg -n "#86EFAC|#93C5FD|#FBBF24|#D4D4D4|#9CA3AF" apps/artax/tests/playground-theme-token-sync.test.ts` returns 0 asserted syntax colors (they appear only inside the exclusion comment, if at all)
+    - `rg -c "getTokensByCategory" apps/artax/tests/playground-theme-token-sync.test.ts` returns ≥1 (reuses the parser, no new CSS parsing)
+    - `pnpm --filter artax test -- playground-theme-token-sync` passes
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax test -- playground-theme-token-sync</automated>
+  </verify>
+  <done>The 3 token-backed Prism hexes are pinned to artax-ui dark tokens by a passing test; syntax colors documented as excluded; parser reused, not duplicated.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| build-time only | Adds one test file that reads in-repo CSS/TS at test time. No runtime, input, auth, or network surface. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-36-02-01 | Tampering | Prism theme literals drifting from tokens | mitigate | The token-sync test fails CI when --background/--primary/--muted-foreground shift, closing the silent-desync gap the file's own header comment warned about. |
+| T-36-02-02 | Information Disclosure | none | accept | No secrets, PII, or user data in scope — static color literals only. |
+</threat_model>
+
+<verification>
+- `pnpm --filter artax test -- playground-theme-token-sync` green
+- `pnpm --filter artax test` still green overall (no regression to token-reference.test.ts)
+</verification>
+
+<success_criteria>
+- The 3 token-backed Prism hexes are machine-verified against artax-ui dark tokens
+- The 5 syntax colors are documented as intentionally excluded
+- The test reuses `getTokensByCategory()` — no second CSS parser introduced
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-02-SUMMARY.md`
+</output>

--- a/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-03-PLAN.md
+++ b/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-03-PLAN.md
@@ -1,0 +1,135 @@
+---
+phase: 36-artax-showcase-parity-design-system-hygiene
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - packages/artax-ui/package.json
+  - apps/artax/package.json
+  - pnpm-lock.yaml
+autonomous: true
+requirements: [DEP-01]
+
+must_haves:
+  truths:
+    - "next is declared as a peerDependency of artax-ui (next/link is imported in prev-next-nav.tsx)"
+    - "prism-react-renderer is declared as a direct dependency of apps/artax (imported in playground-theme.ts)"
+    - "The lockfile reflects the declarations and typecheck/tests stay green"
+  artifacts:
+    - path: "packages/artax-ui/package.json"
+      provides: "next peerDependency declaration"
+      contains: "\"next\""
+    - path: "apps/artax/package.json"
+      provides: "prism-react-renderer direct dependency"
+      contains: "prism-react-renderer"
+  key_links:
+    - from: "packages/artax-ui/src/components/molecules/prev-next-nav/prev-next-nav.tsx"
+      to: "packages/artax-ui/package.json peerDependencies.next"
+      via: "next/link import now backed by a declared peer"
+      pattern: "next/link"
+    - from: "apps/artax/src/lib/playground-theme.ts"
+      to: "apps/artax/package.json dependencies.prism-react-renderer"
+      via: "prism-react-renderer import now backed by a direct dep"
+      pattern: "prism-react-renderer"
+---
+
+<objective>
+Fix two phantom (undeclared) dependencies that currently resolve only via `shamefully-hoist=true`: artax-ui imports `next/link` without declaring `next`, and apps/artax imports `prism-react-renderer` (a transitive of react-live) without declaring it directly. Declare each in the correct manifest field so the imports survive a future hoisting-strictness change.
+
+Purpose: Supply-chain hygiene — every direct import must be a declared dep/peer of the importing package (ASVS V14). This is declaration-only; both packages are already installed.
+Output: `next` added to artax-ui peerDependencies, `prism-react-renderer` added to artax dependencies, refreshed lockfile.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-PATTERNS.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Declare next (artax-ui peer) and prism-react-renderer (artax dep), refresh lockfile</name>
+  <files>packages/artax-ui/package.json, apps/artax/package.json, pnpm-lock.yaml</files>
+  <read_first>
+    - packages/artax-ui/package.json (existing peerDependencies block — next-themes is the precedent)
+    - apps/artax/package.json (existing dependencies block — add alphabetically near next)
+    - packages/artax-ui/src/components/molecules/prev-next-nav/prev-next-nav.tsx (confirms the next/link import that motivates the peer)
+    - apps/artax/src/lib/playground-theme.ts (confirms the prism-react-renderer import that motivates the direct dep)
+    - .planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md (Pitfall 4 — version ranges; Code Examples — exact snippets)
+  </read_first>
+  <action>
+    Two manifest edits following the research's exact recommendations, then a lockfile refresh.
+
+    1. `packages/artax-ui/package.json` — add `next` to `peerDependencies` with a permissive range matching the monorepo major (both apps are on 16.2.x). Match the `next-themes` precedent (framework-provided runtime → peer, NOT a direct dependency):
+       ```jsonc
+       "peerDependencies": {
+         "next": ">=16.0.0",          // NEW — next/link imported in prev-next-nav.tsx
+         "next-themes": ">=0.3.0",
+         "react": "^19.0.0",
+         "react-dom": "^19.0.0"
+       }
+       ```
+       Do NOT add `next` as a full `dependency` (Anti-Pattern). (Optionally add `next` to artax-ui `devDependencies` so its own jest resolves next/link without relying on hoisting — permitted but not required; if added, use the same `>=16.0.0` range.)
+
+    2. `apps/artax/package.json` — promote `prism-react-renderer` from transitive to a direct `dependency`, matching the installed version (2.4.1; react-live also depends `^2.4.0`):
+       ```jsonc
+       "prism-react-renderer": "^2.4.1",   // NEW — imported in src/lib/playground-theme.ts
+       ```
+       Place it alphabetically within the existing `dependencies` block.
+
+    3. Run `pnpm install` to refresh `pnpm-lock.yaml` (both packages are already installed via hoisting, so this only updates the lockfile — no new download expected). Do NOT bypass or edit the lockfile by hand.
+  </action>
+  <acceptance_criteria>
+    - `node -e "const p=require('./packages/artax-ui/package.json'); process.exit(p.peerDependencies && p.peerDependencies.next ? 0 : 1)"` exits 0
+    - `node -e "const p=require('./packages/artax-ui/package.json'); process.exit(p.dependencies && p.dependencies.next ? 1 : 0)"` exits 0 (next is NOT a direct dependency)
+    - `node -e "const p=require('./apps/artax/package.json'); process.exit(p.dependencies && p.dependencies['prism-react-renderer'] ? 0 : 1)"` exits 0
+    - `pnpm install` completes and `pnpm-lock.yaml` is updated (or already consistent) with no error
+    - `pnpm typecheck` and `pnpm test` remain green
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm install && pnpm typecheck</automated>
+  </verify>
+  <done>next is an artax-ui peerDependency; prism-react-renderer is an artax direct dependency; lockfile refreshed; typecheck + tests green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| supply chain (build/install) | Package manifests and lockfile — the surface where dependency resolution is decided. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-36-03-01 | Denial of Service | undeclared next/link + prism-react-renderer resolution | mitigate | Declare `next` (peer) and `prism-react-renderer` (direct dep) so a future `shamefully-hoist`/strictness change cannot silently break the build (ASVS V14). |
+| T-36-03-02 | Tampering | lockfile | mitigate | Refresh via `pnpm install` (never hand-edit); the diff is PR-reviewable and no version range is loosened beyond the research recommendation. |
+</threat_model>
+
+<verification>
+- `pnpm install` refreshes the lockfile without error
+- `pnpm typecheck` green across workspaces
+- `pnpm test` green across workspaces (no resolution regression)
+</verification>
+
+<success_criteria>
+- `next` declared as artax-ui peerDependency (not a direct dep)
+- `prism-react-renderer` declared as an artax direct dependency
+- Lockfile consistent; typecheck + tests green
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-03-SUMMARY.md`
+</output>

--- a/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-04-PLAN.md
+++ b/.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-04-PLAN.md
@@ -1,0 +1,232 @@
+---
+phase: 36-artax-showcase-parity-design-system-hygiene
+plan: 04
+type: execute
+wave: 2
+depends_on: ["01"]
+files_modified:
+  - packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx
+  - packages/artax-ui/src/index.ts
+  - packages/artax-ui/tests/boundaries.test.ts
+  - apps/artax/src/lib/component-registry.ts
+  - apps/artax/tests/component-registry.test.ts
+  - apps/artax/tests/component-counts.test.ts
+  - apps/artax/src/components/header.tsx
+  - apps/blakepetersen.io/src/components/header.tsx
+autonomous: true
+requirements: [DEDUP-01, DEDUP-02, PARITY-01, PARITY-02]
+
+must_haves:
+  truths:
+    - "ThemeToggle lives in packages/artax-ui and is exported from the barrel"
+    - "Both apps import ThemeToggle from 'artax-ui'; no local theme-toggle copies remain"
+    - "ThemeToggle is a documented showcase component; barrel + registry + landing count all read 20"
+    - "The new client file is registered in boundaries.test.ts (client-boundary contract honored)"
+  artifacts:
+    - path: "packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx"
+      provides: "The single shared ThemeToggle (client), 'use client' first line, useTheme from the local provider"
+      min_lines: 80
+    - path: "packages/artax-ui/src/index.ts"
+      provides: "ThemeToggle barrel export under the // Molecules section"
+      contains: "ThemeToggle"
+  key_links:
+    - from: "apps/artax/src/components/header.tsx"
+      to: "packages/artax-ui/src/index.ts"
+      via: "import { ThemeToggle } from 'artax-ui'"
+      pattern: "from ['\"]artax-ui['\"]"
+    - from: "apps/blakepetersen.io/src/components/header.tsx"
+      to: "packages/artax-ui/src/index.ts"
+      via: "import { ThemeToggle } from 'artax-ui'"
+      pattern: "from ['\"]artax-ui['\"]"
+    - from: "packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx"
+      to: "packages/artax-ui/src/providers/theme-provider.tsx"
+      via: "import { useTheme } from '../../../providers/theme-provider'"
+      pattern: "providers/theme-provider"
+---
+
+<objective>
+The 87-line ThemeToggle is byte-identical in both apps — a direct violation of the repo's own design-system rule (reusable components live in artax-ui, never copy-pasted into app dirs). Move it into artax-ui as a `molecules/theme-toggle` component, export it from the barrel, register it in the client-boundary contract, document it as a showcase component (bumping barrel + registry + landing count from 19 → 20 per the locked Open Q1 decision), then switch both apps to the barrel import and delete the two local copies.
+
+Purpose: One reusable primitive, one edit site, design-system rule honored. The showcase documents every component the design system exports — so ThemeToggle becomes the 20th.
+Output: New shared ThemeToggle in artax-ui, barrel + boundaries + showcase entry, both headers rewired, both local copies deleted, all counts at 20.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-RESEARCH.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-PATTERNS.md
+@.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-01-SUMMARY.md
+
+<interfaces>
+<!-- Client-header ordering precedent (Open Q2, RESOLVED). Source: organisms/modal/modal.tsx:1-3 -->
+```typescript
+'use client'
+// ABOUTME: Modal — thin composition over artax-ui Dialog with size slots.
+// ABOUTME: Applies mounted-flag SSR gate per Phase 24.1 D-09 for above-the-fold usage.
+```
+<!-- 'use client' MUST be the literal first line (boundaries.test.ts firstLine assertion),
+     ABOUTME lines 2-3 after it. The current app copies put ABOUTME first — that ordering FAILS. -->
+
+<!-- Barrel section markers are load-bearing: exporting ThemeToggle under // Molecules makes
+     component-counts.ts count it (molecules 9 → 10, total 19 → 20), which requires the
+     registry to document it to keep the parity test green. This is the Open Q1 hinge (LOCKED = document, total 20). -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Move ThemeToggle into artax-ui (barrel export + boundaries registration)</name>
+  <files>packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx, packages/artax-ui/src/index.ts, packages/artax-ui/tests/boundaries.test.ts</files>
+  <read_first>
+    - apps/artax/src/components/theme-toggle.tsx (verbatim source — 87 lines incl. the 3 inline SVG icons and useSyncExternalStore mount guard)
+    - packages/artax-ui/src/components/organisms/modal/modal.tsx (header ordering precedent: 'use client' line 1, ABOUTME after)
+    - packages/artax-ui/src/providers/theme-provider.tsx (exports useTheme — the internal import target)
+    - packages/artax-ui/src/index.ts (existing molecule export lines + the // Molecules / // Providers section markers)
+    - packages/artax-ui/tests/boundaries.test.ts (clientFiles array lines 22-31; firstLine assertion lines 61-73; coverage assertion lines 84-89)
+  </read_first>
+  <action>
+    Create NEW file `packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx` by copying the body of `apps/artax/src/components/theme-toggle.tsx` VERBATIM, with exactly TWO changes:
+
+    1. Header ordering (Open Q2, resolved by modal.tsx precedent): `'use client'` is the LITERAL first line, then the existing 2-line `// ABOUTME:` comment on lines 2-3. Do NOT keep the app copy's ABOUTME-first ordering — it fails the boundaries test's `firstLine === "'use client'"` assertion.
+    2. Swap the theme import from `next-themes` to the artax-ui provider (decision 22-02 — artax-ui dogfoods its own re-export, keeps the peer surface at next-themes with no new peer):
+       ```typescript
+       import { useTheme } from '../../../providers/theme-provider'
+       ```
+    Keep the 3 hand-rolled inline SVG icons (Sun/Moon/Monitor) as-is — do NOT add lucide-react for 3 glyphs (YAGNI). Keep the `useSyncExternalStore` mount guard and the `cycleTheme` (dark→light→system→dark) logic unchanged.
+
+    Add the barrel export in `packages/artax-ui/src/index.ts` under the `// Molecules` section (placement is what makes component-counts count it → total 20):
+    ```typescript
+    export { ThemeToggle } from './components/molecules/theme-toggle/theme-toggle'
+    ```
+    `index.ts` itself must NOT contain `'use client'` — only the component file carries the directive.
+
+    Register the new client file in `packages/artax-ui/tests/boundaries.test.ts` `clientFiles` array (same commit — decision 26-01 coverage assertion):
+    ```typescript
+    'molecules/theme-toggle/theme-toggle.tsx',   // NEW
+    ```
+
+    NOTE: after this task the barrel exports 20 but the artax registry still documents 19 → artax tests (parity + counts) will be RED until Task 2. That is expected; Task 1's gate is the artax-ui boundaries suite, which stays green.
+  </action>
+  <acceptance_criteria>
+    - `packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx` exists; `head -1` of the file is exactly `'use client'`; lines 2-3 match `^// ABOUTME:`
+    - `rg -n "from 'next-themes'" packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx` returns 0 (uses the local provider instead)
+    - `rg -n "providers/theme-provider" packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx` returns 1
+    - `rg -n "export \{ ThemeToggle \}" packages/artax-ui/src/index.ts` returns 1, under the `// Molecules` section
+    - `rg -n "molecules/theme-toggle/theme-toggle.tsx" packages/artax-ui/tests/boundaries.test.ts` returns 1 (in clientFiles)
+    - `pnpm --filter artax-ui test` passes (boundaries suite green — new file registered + 'use client' first line)
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax-ui test</automated>
+  </verify>
+  <done>ThemeToggle lives in artax-ui/molecules, exported from the barrel, registered in boundaries.test.ts with 'use client' first; artax-ui suite green. (artax registry catch-up happens in Task 2.)</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Document ThemeToggle as the 20th showcase component; reconcile counts 19 → 20</name>
+  <files>apps/artax/src/lib/component-registry.ts, apps/artax/tests/component-registry.test.ts, apps/artax/tests/component-counts.test.ts</files>
+  <read_first>
+    - apps/artax/src/lib/component-registry.ts (molecule ComponentDef template — Callout entry; import block; getSidebarSections molecules block)
+    - apps/artax/tests/component-registry.test.ts (EXPECTED_MOLECULES; molecules length + total assertions; EXCLUDED_PLAYGROUND_SLUGS — all set to 19 by Plan 01)
+    - apps/artax/tests/component-counts.test.ts (barrel-derived molecules 9 / total 19 assertions — bump to 10 / 20)
+    - packages/artax-ui/src/components/molecules/theme-toggle/theme-toggle.tsx (props: ThemeToggle takes no required props; preview renders <ThemeToggle />)
+  </read_first>
+  <action>
+    Make the artax registry catch up to the barrel's new 20th export (Plan 01 landed everything at 19; this task moves the molecule tier and totals to 20).
+
+    1. `apps/artax/src/lib/component-registry.ts`:
+       - Add `ThemeToggle` to the `from 'artax-ui'` import.
+       - Add a molecule `ComponentDef` in the `// ──── Molecules ──` section, mirroring the Callout field ordering. `slug: 'theme-toggle'` (MUST equal the artax-ui folder name — parity key); `tier: 'molecules'`; `imports: "import { ThemeToggle } from 'artax-ui'"`; `props` describes the (prop-less) API — document at minimum the interactive behavior (cycles dark→light→system) and that it takes no required props (use a single descriptive `props` entry so `props.length > 0` holds); `codeExamples` includes `{ label: 'Basic', code: '<ThemeToggle />' }`; `a11y` describes the aria-label + button semantics (length > 0); `preview: () => h(ThemeToggle)`. OMIT the `playground` key (ship preview-only).
+       - Add a sidebar entry in the molecules block: `{ name: 'ThemeToggle', href: '/components/molecules/theme-toggle' }`.
+    2. `apps/artax/tests/component-registry.test.ts`:
+       - `EXPECTED_MOLECULES`: add `'theme-toggle'`.
+       - molecules length `9` → `10`; total `toHaveLength(19)` → `toHaveLength(20)`; `getComponentsByTier('molecules')` `9` → `10`.
+       - `EXCLUDED_PLAYGROUND_SLUGS`: add `'theme-toggle'` (no playground key → excluded bucket; the no-overlap/no-gap assertion requires it).
+    3. `apps/artax/tests/component-counts.test.ts`: molecules `9` → `10`; total `19` → `20` (the barrel now exports ThemeToggle under // Molecules).
+
+    The barrel↔registry parity test (from Plan 01) needs NO edit — it auto-passes once both sides include `theme-toggle`.
+  </action>
+  <acceptance_criteria>
+    - `rg -n "slug: 'theme-toggle'" apps/artax/src/lib/component-registry.ts` returns 1
+    - `rg -n "toHaveLength\(20\)" apps/artax/tests/component-registry.test.ts` returns ≥1; no remaining `toHaveLength(19)` total assertion
+    - `rg -n "'theme-toggle'" apps/artax/tests/component-registry.test.ts` shows it in both EXPECTED_MOLECULES and EXCLUDED_PLAYGROUND_SLUGS
+    - `rg -n "\b20\b" apps/artax/tests/component-counts.test.ts` shows the updated total assertion
+    - `pnpm --filter artax test` passes (registry, counts, barrel-registry-parity, playground partition all green at 20)
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm --filter artax test</automated>
+  </verify>
+  <done>ThemeToggle documented as the 20th component; molecules 10 / total 20 across registry + counts; parity test green; playground partition covers it.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Rewire both app headers to the barrel import; delete the two local copies</name>
+  <files>apps/artax/src/components/header.tsx, apps/blakepetersen.io/src/components/header.tsx</files>
+  <read_first>
+    - apps/artax/src/components/header.tsx (import line ~7: `import { ThemeToggle } from '@/components/theme-toggle'`)
+    - apps/blakepetersen.io/src/components/header.tsx (import line ~8: `import { ThemeToggle } from './theme-toggle'`)
+  </read_first>
+  <action>
+    Switch both headers to the shared barrel import and remove the duplicates.
+
+    1. `apps/artax/src/components/header.tsx`: replace the local import with `import { ThemeToggle } from 'artax-ui'`. Usage `<ThemeToggle />` is unchanged.
+    2. `apps/blakepetersen.io/src/components/header.tsx`: replace the local import with `import { ThemeToggle } from 'artax-ui'`. Usage unchanged.
+    3. DELETE `apps/artax/src/components/theme-toggle.tsx`.
+    4. DELETE `apps/blakepetersen.io/src/components/theme-toggle.tsx`.
+
+    (If either header previously imported `ThemeToggle` alongside other artax-ui symbols, merge into the existing `from 'artax-ui'` import rather than adding a second import line.)
+  </action>
+  <acceptance_criteria>
+    - `rg -c "components/theme-toggle" apps` returns 0 (no remaining references to the local copies — DEDUP-02)
+    - `apps/artax/src/components/theme-toggle.tsx` and `apps/blakepetersen.io/src/components/theme-toggle.tsx` do not exist
+    - Both headers contain `import { ThemeToggle } from 'artax-ui'` (or ThemeToggle merged into an existing artax-ui import)
+    - `pnpm typecheck` green for both apps
+    - `pnpm test` green across all workspaces
+  </acceptance_criteria>
+  <verify>
+    <automated>pnpm typecheck && pnpm test</automated>
+  </verify>
+  <done>Both apps import ThemeToggle from artax-ui; both local copies deleted; `rg -c "components/theme-toggle" apps` == 0; full suite + typecheck green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| build-time / client render | Moves a client component + documentation data. No auth, session, access-control, or user-input surface. next-themes owns the localStorage `theme` key — unchanged by the move. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-36-04-01 | Tampering | client-boundary contract (new .tsx) | mitigate | Register `molecules/theme-toggle/theme-toggle.tsx` in boundaries.test.ts clientFiles with `'use client'` as the literal first line — the coverage assertion enforces SSR-safety classification in the same commit (decision 26-01). |
+| T-36-04-02 | Denial of Service | theme persistence | accept | next-themes stores preference under its default `theme` key, owned by ThemeProvider; the code-move does not change the key, so no stored-value migration or reset risk. |
+</threat_model>
+
+<verification>
+- `pnpm --filter artax-ui test` green (boundaries: new client file registered, 'use client' first)
+- `pnpm --filter artax test` green (registry + counts + parity at 20)
+- `pnpm typecheck && pnpm test` green across all workspaces
+- `rg -c "components/theme-toggle" apps` == 0
+- Manual (phase-end, per 36-VALIDATION.md): toggle theme in both apps' headers — light/dark switch persists identically after the move
+</verification>
+
+<success_criteria>
+- ThemeToggle lives once, in artax-ui, exported from the barrel and registered as a client file
+- Both apps import it from 'artax-ui'; no local copies remain
+- Documented as the 20th showcase component; barrel + registry + landing count all read 20; parity test green
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/36-artax-showcase-parity-design-system-hygiene/36-04-SUMMARY.md`
+</output>


### PR DESCRIPTION
## Summary
- Records the Blake-approved dual-Ajv → safeParse decision in STATE.md (supersedes LINT-01/28-02) and annotates REQUIREMENTS.md
- Marks Phase 31 complete in ROADMAP.md (6/6 plans, merged as #137)
- Adds Phase 36 planning artifacts (planner's docs commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)